### PR TITLE
Make NFC AID handling configurable at runtime

### DIFF
--- a/app/src/main/java/com/lnkv/nfcemulator/MainActivity.kt
+++ b/app/src/main/java/com/lnkv/nfcemulator/MainActivity.kt
@@ -1,47 +1,122 @@
 package com.lnkv.nfcemulator
 
+import android.content.ComponentName
+import android.content.SharedPreferences
+import android.nfc.NfcAdapter
+import android.nfc.cardemulation.CardEmulation
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.padding
-import androidx.compose.material3.Scaffold
+import androidx.compose.foundation.ScrollState
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Button
+import androidx.compose.material3.Checkbox
 import androidx.compose.material3.Text
-import androidx.compose.runtime.Composable
+import androidx.compose.material3.TextField
+import androidx.compose.runtime.*
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.lnkv.nfcemulator.cardservice.TypeAEmulatorService
 import com.lnkv.nfcemulator.ui.theme.NFCEmulatorTheme
 
 class MainActivity : ComponentActivity() {
+    private lateinit var cardEmulation: CardEmulation
+    private lateinit var componentName: ComponentName
+    private lateinit var prefs: SharedPreferences
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()
+
+        val nfcAdapter = NfcAdapter.getDefaultAdapter(this)
+        cardEmulation = CardEmulation.getInstance(nfcAdapter)
+        componentName = ComponentName(this, TypeAEmulatorService::class.java)
+        prefs = getSharedPreferences("nfc_aids", MODE_PRIVATE)
+
+        val storedAids = prefs.getStringSet("aids", setOf("F0010203040506"))!!.toList()
+        registerAids(storedAids)
+
         setContent {
             NFCEmulatorTheme {
-                Scaffold(modifier = Modifier.fillMaxSize()) { innerPadding ->
-                    Greeting(
-                        name = "Android",
-                        modifier = Modifier.padding(innerPadding)
-                    )
+                var aid1 by rememberSaveable { mutableStateOf(storedAids.getOrNull(0) ?: "") }
+                var aid2 by rememberSaveable { mutableStateOf(storedAids.getOrNull(1) ?: "") }
+                var showAid1 by rememberSaveable { mutableStateOf(true) }
+                var showAid2 by rememberSaveable { mutableStateOf(true) }
+                val scrollState1 = rememberScrollState()
+                val scrollState2 = rememberScrollState()
+
+                Column(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .padding(16.dp)
+                ) {
+                    Row(verticalAlignment = Alignment.CenterVertically) {
+                        Checkbox(
+                            checked = showAid1,
+                            onCheckedChange = { checked ->
+                                if (!checked && !showAid2) return@Checkbox
+                                showAid1 = checked
+                            }
+                        )
+                        Text("Show AID 1")
+                    }
+                    if (showAid1) {
+                        ScrollableTextField(aid1, { aid1 = it }, scrollState1, "AID 1")
+                    }
+
+                    Row(verticalAlignment = Alignment.CenterVertically) {
+                        Checkbox(
+                            checked = showAid2,
+                            onCheckedChange = { checked ->
+                                if (!checked && !showAid1) return@Checkbox
+                                showAid2 = checked
+                            }
+                        )
+                        Text("Show AID 2")
+                    }
+                    if (showAid2) {
+                        ScrollableTextField(aid2, { aid2 = it }, scrollState2, "AID 2")
+                    }
+
+                    Spacer(modifier = Modifier.height(16.dp))
+                    Button(onClick = {
+                        val aids = mutableListOf<String>()
+                        if (showAid1 && aid1.isNotBlank()) aids.add(aid1)
+                        if (showAid2 && aid2.isNotBlank()) aids.add(aid2)
+                        registerAids(aids)
+                        prefs.edit().putStringSet("aids", aids.toSet()).apply()
+                    }) {
+                        Text("Save AIDs")
+                    }
                 }
             }
         }
     }
-}
 
-@Composable
-fun Greeting(name: String, modifier: Modifier = Modifier) {
-    Text(
-        text = "Hello $name!",
-        modifier = modifier
-    )
-}
-
-@Preview(showBackground = true)
-@Composable
-fun GreetingPreview() {
-    NFCEmulatorTheme {
-        Greeting("Android")
+    private fun registerAids(aids: List<String>) {
+        cardEmulation.registerAidsForService(componentName, CardEmulation.CATEGORY_OTHER, aids)
     }
+}
+
+@Composable
+private fun ScrollableTextField(
+    value: String,
+    onValueChange: (String) -> Unit,
+    scrollState: ScrollState,
+    label: String
+) {
+    TextField(
+        value = value,
+        onValueChange = onValueChange,
+        modifier = Modifier
+            .fillMaxWidth()
+            .height(120.dp)
+            .verticalScroll(scrollState),
+        label = { Text(label) }
+    )
 }

--- a/app/src/main/java/com/lnkv/nfcemulator/cardservice/TypeAEmulatorService.kt
+++ b/app/src/main/java/com/lnkv/nfcemulator/cardservice/TypeAEmulatorService.kt
@@ -12,7 +12,14 @@ class TypeAEmulatorService : HostApduService() {
         val apduHex = commandApdu.joinToString("") { "%02X".format(it.toInt() and 0xFF) }
         Log.d(TAG, "APDU: $apduHex")
 
-        return if (commandApdu.contentEquals(SELECT_APDU)) SELECT_OK else UNKNOWN_COMMAND
+        return if (isSelectCommand(commandApdu)) SELECT_OK else UNKNOWN_COMMAND
+    }
+
+    private fun isSelectCommand(apdu: ByteArray): Boolean {
+        return apdu.size >= 4 &&
+            apdu[0] == 0x00.toByte() &&
+            apdu[1] == 0xA4.toByte() &&
+            apdu[2] == 0x04.toByte()
     }
 
     override fun onDeactivated(reason: Int) {
@@ -21,14 +28,6 @@ class TypeAEmulatorService : HostApduService() {
 
     companion object {
         private const val TAG = "TypeAEmulatorService"
-
-        // ISO 7816-4 SELECT command for our AID (F0010203040506)
-        private val SELECT_APDU = byteArrayOf(
-            0x00.toByte(), 0xA4.toByte(), 0x04.toByte(), 0x00.toByte(),
-            0x07.toByte(),
-            0xF0.toByte(), 0x01.toByte(), 0x02.toByte(), 0x03.toByte(), 0x04.toByte(), 0x05.toByte(), 0x06.toByte(),
-            0x00.toByte()
-        )
 
         private val SELECT_OK = byteArrayOf(0x90.toByte(), 0x00.toByte())
         private val UNKNOWN_COMMAND = byteArrayOf(0x6A.toByte(), 0x82.toByte())

--- a/app/src/main/res/xml/apduservice.xml
+++ b/app/src/main/res/xml/apduservice.xml
@@ -2,7 +2,5 @@
 <host-apdu-service xmlns:android="http://schemas.android.com/apk/res/android"
     android:description="@string/app_name"
     android:requireDeviceUnlock="false">
-    <aid-group android:category="other" android:description="@string/app_name">
-        <aid-filter android:name="F0010203040506"/>
-    </aid-group>
+    <aid-group android:category="other" android:description="@string/app_name" />
 </host-apdu-service>


### PR DESCRIPTION
## Summary
- Allow users to enter and save NFC AIDs at runtime and register them dynamically
- Provide scrollable twin text fields with visibility toggles to manage AID entries
- Simplify Type A service to handle generic SELECT commands

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_689cb847d8a48330afdce443f171e6c9