### PR TITLE
Add APDU communication log view

### DIFF
--- a/app/src/main/java/com/lnkv/nfcemulator/CommunicationLog.kt
+++ b/app/src/main/java/com/lnkv/nfcemulator/CommunicationLog.kt
@@ -1,0 +1,23 @@
+package com.lnkv.nfcemulator
+
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+
+/**
+ * Holds APDU communication logs between the external reader and the emulator.
+ */
+object CommunicationLog {
+    data class Entry(val message: String, val isRequest: Boolean)
+
+    private val _entries = MutableStateFlow<List<Entry>>(emptyList())
+    val entries = _entries.asStateFlow()
+
+    /**
+     * Appends a new log entry.
+     * @param message Hex representation of APDU data.
+     * @param isRequest True if the message came from the external reader.
+     */
+    fun add(message: String, isRequest: Boolean) {
+        _entries.value = _entries.value + Entry(message, isRequest)
+    }
+}

--- a/app/src/main/java/com/lnkv/nfcemulator/MainActivity.kt
+++ b/app/src/main/java/com/lnkv/nfcemulator/MainActivity.kt
@@ -12,6 +12,8 @@ import androidx.compose.foundation.ScrollState
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
 import androidx.compose.material3.Button
 import androidx.compose.material3.Checkbox
 import androidx.compose.material3.Text
@@ -20,6 +22,7 @@ import androidx.compose.runtime.*
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import com.lnkv.nfcemulator.cardservice.TypeAEmulatorService
 import com.lnkv.nfcemulator.ui.theme.NFCEmulatorTheme
@@ -49,6 +52,7 @@ class MainActivity : ComponentActivity() {
                 var showAid2 by rememberSaveable { mutableStateOf(true) }
                 val scrollState1 = rememberScrollState()
                 val scrollState2 = rememberScrollState()
+                val logEntries by CommunicationLog.entries.collectAsState()
 
                 Column(
                     modifier = Modifier
@@ -92,6 +96,21 @@ class MainActivity : ComponentActivity() {
                         prefs.edit().putStringSet("aids", aids.toSet()).apply()
                     }) {
                         Text("Save AIDs")
+                    }
+
+                    Spacer(modifier = Modifier.height(16.dp))
+                    Text("Communication Log")
+                    LazyColumn(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .weight(1f)
+                    ) {
+                        items(logEntries) { entry ->
+                            Text(
+                                text = entry.message,
+                                color = if (entry.isRequest) Color.Red else Color.Green
+                            )
+                        }
                     }
                 }
             }

--- a/app/src/main/java/com/lnkv/nfcemulator/cardservice/TypeAEmulatorService.kt
+++ b/app/src/main/java/com/lnkv/nfcemulator/cardservice/TypeAEmulatorService.kt
@@ -3,16 +3,21 @@ package com.lnkv.nfcemulator.cardservice
 import android.nfc.cardemulation.HostApduService
 import android.os.Bundle
 import android.util.Log
+import com.lnkv.nfcemulator.CommunicationLog
 
 class TypeAEmulatorService : HostApduService() {
 
     override fun processCommandApdu(commandApdu: ByteArray?, extras: Bundle?): ByteArray {
         if (commandApdu == null) return UNKNOWN_COMMAND
 
-        val apduHex = commandApdu.joinToString("") { "%02X".format(it.toInt() and 0xFF) }
+        val apduHex = commandApdu.toHex()
         Log.d(TAG, "APDU: $apduHex")
+        CommunicationLog.add("REQ: $apduHex", true)
 
-        return if (isSelectCommand(commandApdu)) SELECT_OK else UNKNOWN_COMMAND
+        val response = if (isSelectCommand(commandApdu)) SELECT_OK else UNKNOWN_COMMAND
+        CommunicationLog.add("RESP: ${response.toHex()}", false)
+
+        return response
     }
 
     private fun isSelectCommand(apdu: ByteArray): Boolean {
@@ -33,3 +38,6 @@ class TypeAEmulatorService : HostApduService() {
         private val UNKNOWN_COMMAND = byteArrayOf(0x6A.toByte(), 0x82.toByte())
     }
 }
+
+private fun ByteArray.toHex(): String =
+    joinToString("") { "%02X".format(it.toInt() and 0xFF) }


### PR DESCRIPTION
## Summary
- track incoming and outgoing APDU commands via a shared log
- show communication log in activity with color-coded requests and responses

## Testing
- `sh gradlew test` *(fails: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_689e423285e08330a1a2360afec1da3e