### PR TITLE
Add navigation and communication log screens with tests

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -50,6 +50,7 @@ dependencies {
     implementation(libs.androidx.ui.tooling.preview)
     implementation(libs.androidx.material3)
     implementation(libs.androidx.runtime.saveable)
+    implementation(libs.androidx.material.icons.extended)
     testImplementation(libs.junit)
     testImplementation(platform(libs.androidx.compose.bom))
     testImplementation(libs.androidx.ui.test.junit4)

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -50,6 +50,8 @@ dependencies {
     implementation(libs.androidx.ui.tooling.preview)
     implementation(libs.androidx.material3)
     testImplementation(libs.junit)
+    testImplementation(platform(libs.androidx.compose.bom))
+    testImplementation(libs.androidx.ui.test.junit4)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)
     androidTestImplementation(platform(libs.androidx.compose.bom))

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -49,6 +49,7 @@ dependencies {
     implementation(libs.androidx.ui.graphics)
     implementation(libs.androidx.ui.tooling.preview)
     implementation(libs.androidx.material3)
+    implementation(libs.androidx.runtime.saveable)
     testImplementation(libs.junit)
     testImplementation(platform(libs.androidx.compose.bom))
     testImplementation(libs.androidx.ui.test.junit4)

--- a/app/src/main/java/com/lnkv/nfcemulator/CommunicationLog.kt
+++ b/app/src/main/java/com/lnkv/nfcemulator/CommunicationLog.kt
@@ -20,4 +20,12 @@ object CommunicationLog {
     fun add(message: String, isRequest: Boolean) {
         _entries.value = _entries.value + Entry(message, isRequest)
     }
+
+    /**
+     * Clears all stored log entries. Useful for resetting state in tests or when
+     * starting a new emulation session.
+     */
+    fun clear() {
+        _entries.value = emptyList()
+    }
 }

--- a/app/src/main/java/com/lnkv/nfcemulator/CommunicationLog.kt
+++ b/app/src/main/java/com/lnkv/nfcemulator/CommunicationLog.kt
@@ -2,6 +2,7 @@ package com.lnkv.nfcemulator
 
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import java.io.File
 
 /**
  * Holds APDU communication logs between the external reader and the emulator.
@@ -27,5 +28,13 @@ object CommunicationLog {
      */
     fun clear() {
         _entries.value = emptyList()
+    }
+
+    /**
+     * Writes all log entries to the provided [file], each message separated by a newline.
+     */
+    fun saveToFile(file: File) {
+        val text = _entries.value.joinToString("\n") { it.message }
+        file.writeText(text)
     }
 }

--- a/app/src/main/java/com/lnkv/nfcemulator/MainActivity.kt
+++ b/app/src/main/java/com/lnkv/nfcemulator/MainActivity.kt
@@ -18,17 +18,9 @@ import androidx.compose.runtime.setValue
 import androidx.compose.runtime.collectAsState
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.graphics.Color
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.weight
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material3.Checkbox
@@ -67,7 +59,7 @@ class MainActivity : ComponentActivity() {
                 androidx.compose.material3.Scaffold(
                     bottomBar = {
                         NavigationBar {
-                            Screen.values().forEach { screen ->
+                            Screen.entries.forEach { screen ->
                                 NavigationBarItem(
                                     selected = currentScreen == screen,
                                     onClick = { currentScreen = screen },
@@ -115,31 +107,26 @@ fun CommunicationScreen(
     var showOutgoing by rememberSaveable { mutableStateOf(true) }
 
     Column(modifier = modifier.fillMaxSize().padding(16.dp)) {
-        Row(
-            verticalAlignment = Alignment.CenterVertically,
-            modifier = Modifier.fillMaxWidth()
-        ) {
-            Row(verticalAlignment = Alignment.CenterVertically) {
-                Checkbox(
-                    checked = showIncoming,
-                    onCheckedChange = { checked ->
-                        if (!checked && !showOutgoing) return@Checkbox
-                        showIncoming = checked
-                    }
-                )
-                Text("Show Incoming Communication")
-            }
-            Spacer(modifier = Modifier.weight(1f))
-            Row(verticalAlignment = Alignment.CenterVertically) {
-                Checkbox(
-                    checked = showOutgoing,
-                    onCheckedChange = { checked ->
-                        if (!checked && !showIncoming) return@Checkbox
-                        showOutgoing = checked
-                    }
-                )
-                Text("Show Outgoing Communication")
-            }
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            Checkbox(
+                checked = showIncoming,
+                onCheckedChange = { checked ->
+                    if (!checked && !showOutgoing) return@Checkbox
+                    showIncoming = checked
+                }
+            )
+            Text("Show Incoming Communication")
+        }
+        Spacer(modifier = Modifier.height(8.dp))
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            Checkbox(
+                checked = showOutgoing,
+                onCheckedChange = { checked ->
+                    if (!checked && !showIncoming) return@Checkbox
+                    showOutgoing = checked
+                }
+            )
+            Text("Show Outgoing Communication")
         }
 
         Spacer(modifier = Modifier.height(8.dp))

--- a/app/src/main/java/com/lnkv/nfcemulator/MainActivity.kt
+++ b/app/src/main/java/com/lnkv/nfcemulator/MainActivity.kt
@@ -13,7 +13,7 @@ import androidx.compose.material3.NavigationBarItem
 import androidx.compose.material3.Text
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.rememberSaveable
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.runtime.collectAsState
 import androidx.compose.ui.Modifier

--- a/app/src/main/java/com/lnkv/nfcemulator/MainActivity.kt
+++ b/app/src/main/java/com/lnkv/nfcemulator/MainActivity.kt
@@ -14,6 +14,7 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.Divider
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -88,7 +89,11 @@ fun MainScreen() {
 
     androidx.compose.material3.Scaffold(
         topBar = {
-            TopAppBar(title = { Text(currentScreen.label, modifier = Modifier.testTag("ScreenHeader")) })
+            TopAppBar(
+                modifier = Modifier.testTag("TopBar"),
+                colors = TopAppBarDefaults.topAppBarColors(containerColor = MaterialTheme.colorScheme.primary),
+                title = { Text(currentScreen.label, modifier = Modifier.testTag("ScreenHeader")) }
+            )
         },
         bottomBar = {
             NavigationBar {
@@ -122,10 +127,13 @@ fun CommunicationScreen(
     var showServer by rememberSaveable { mutableStateOf(true) }
     var showNfc by rememberSaveable { mutableStateOf(true) }
 
-    Column(modifier = modifier.fillMaxSize().padding(16.dp)) {
+    Column(modifier = modifier.fillMaxSize().padding(vertical = 16.dp)) {
         Row(
             verticalAlignment = Alignment.CenterVertically,
-            modifier = Modifier.fillMaxWidth().testTag("ServerToggle")
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 16.dp)
+                .testTag("ServerToggle")
         ) {
             Checkbox(
                 checked = showServer,
@@ -139,7 +147,10 @@ fun CommunicationScreen(
         Spacer(modifier = Modifier.height(4.dp))
         Row(
             verticalAlignment = Alignment.CenterVertically,
-            modifier = Modifier.fillMaxWidth().testTag("NfcToggle")
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 16.dp)
+                .testTag("NfcToggle")
         ) {
             Checkbox(
                 checked = showNfc,
@@ -155,6 +166,7 @@ fun CommunicationScreen(
         Divider(
             modifier = Modifier
                 .fillMaxWidth()
+                .padding(horizontal = 16.dp)
                 .align(Alignment.CenterHorizontally)
                 .testTag("ToggleDivider")
         )
@@ -169,14 +181,18 @@ fun CommunicationScreen(
                     label = "Server Communication",
                     entries = serverEntries,
                     tag = "ServerLog",
-                    modifier = Modifier.weight(1f)
+                    modifier = Modifier
+                        .weight(1f)
+                        .padding(horizontal = 16.dp)
                 )
                 Spacer(modifier = Modifier.height(8.dp))
                 CommunicationLogList(
                     label = "NFC Communication",
                     entries = nfcEntries,
                     tag = "NfcLog",
-                    modifier = Modifier.weight(1f)
+                    modifier = Modifier
+                        .weight(1f)
+                        .padding(horizontal = 16.dp)
                 )
             }
             showServer -> {
@@ -184,7 +200,9 @@ fun CommunicationScreen(
                     label = "Server Communication",
                     entries = serverEntries,
                     tag = "ServerLog",
-                    modifier = Modifier.weight(1f)
+                    modifier = Modifier
+                        .weight(1f)
+                        .padding(horizontal = 16.dp)
                 )
             }
             showNfc -> {
@@ -192,7 +210,9 @@ fun CommunicationScreen(
                     label = "NFC Communication",
                     entries = nfcEntries,
                     tag = "NfcLog",
-                    modifier = Modifier.weight(1f)
+                    modifier = Modifier
+                        .weight(1f)
+                        .padding(horizontal = 16.dp)
                 )
             }
         }

--- a/app/src/main/java/com/lnkv/nfcemulator/MainActivity.kt
+++ b/app/src/main/java/com/lnkv/nfcemulator/MainActivity.kt
@@ -28,11 +28,13 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.weight
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material3.Checkbox
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment.Companion.Center
+import androidx.compose.ui.platform.testTag
 import com.lnkv.nfcemulator.cardservice.TypeAEmulatorService
 import com.lnkv.nfcemulator.ui.theme.NFCEmulatorTheme
 
@@ -113,49 +115,69 @@ fun CommunicationScreen(
     var showOutgoing by rememberSaveable { mutableStateOf(true) }
 
     Column(modifier = modifier.fillMaxSize().padding(16.dp)) {
-        Row(verticalAlignment = Alignment.CenterVertically) {
-            Checkbox(
-                checked = showIncoming,
-                onCheckedChange = { checked ->
-                    if (!checked && !showOutgoing) return@Checkbox
-                    showIncoming = checked
-                }
-            )
-            Text("Show Incoming Communication")
-        }
-        if (showIncoming) {
-            LazyColumn(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .weight(1f)
-            ) {
-                items(entries.filter { it.isRequest }) { entry ->
-                    Text(entry.message, color = Color.Red)
-                }
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            modifier = Modifier.fillMaxWidth()
+        ) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Checkbox(
+                    checked = showIncoming,
+                    onCheckedChange = { checked ->
+                        if (!checked && !showOutgoing) return@Checkbox
+                        showIncoming = checked
+                    }
+                )
+                Text("Show Incoming Communication")
+            }
+            Spacer(modifier = Modifier.weight(1f))
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Checkbox(
+                    checked = showOutgoing,
+                    onCheckedChange = { checked ->
+                        if (!checked && !showIncoming) return@Checkbox
+                        showOutgoing = checked
+                    }
+                )
+                Text("Show Outgoing Communication")
             }
         }
 
         Spacer(modifier = Modifier.height(8.dp))
 
-        Row(verticalAlignment = Alignment.CenterVertically) {
-            Checkbox(
-                checked = showOutgoing,
-                onCheckedChange = { checked ->
-                    if (!checked && !showIncoming) return@Checkbox
-                    showOutgoing = checked
-                }
-            )
-            Text("Show Outgoing Communication")
-        }
-        if (showOutgoing) {
-            LazyColumn(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .weight(1f)
-            ) {
-                items(entries.filter { !it.isRequest }) { entry ->
-                    Text(entry.message, color = Color.Green)
-                }
+        val incomingEntries = entries.filter { it.isRequest }
+        val outgoingEntries = entries.filter { !it.isRequest }
+
+        when {
+            showIncoming && showOutgoing -> {
+                CommunicationLogList(
+                    label = "Incoming Communication",
+                    entries = incomingEntries,
+                    tag = "IncomingLog",
+                    modifier = Modifier.weight(1f)
+                )
+                Spacer(modifier = Modifier.height(8.dp))
+                CommunicationLogList(
+                    label = "Outgoing Communication",
+                    entries = outgoingEntries,
+                    tag = "OutgoingLog",
+                    modifier = Modifier.weight(1f)
+                )
+            }
+            showIncoming -> {
+                CommunicationLogList(
+                    label = "Incoming Communication",
+                    entries = incomingEntries,
+                    tag = "IncomingLog",
+                    modifier = Modifier.weight(1f)
+                )
+            }
+            showOutgoing -> {
+                CommunicationLogList(
+                    label = "Outgoing Communication",
+                    entries = outgoingEntries,
+                    tag = "OutgoingLog",
+                    modifier = Modifier.weight(1f)
+                )
             }
         }
     }
@@ -165,6 +187,28 @@ fun CommunicationScreen(
 fun PlaceholderScreen(text: String, modifier: Modifier = Modifier) {
     Box(modifier = modifier.fillMaxSize(), contentAlignment = Center) {
         Text(text)
+    }
+}
+
+@Composable
+private fun CommunicationLogList(
+    label: String,
+    entries: List<CommunicationLog.Entry>,
+    tag: String,
+    modifier: Modifier = Modifier
+) {
+    Column(modifier.fillMaxWidth()) {
+        Text(label)
+        LazyColumn(
+            modifier = Modifier
+                .fillMaxSize()
+                .testTag(tag)
+        ) {
+            items(entries) { entry ->
+                val color = if (entry.isRequest) Color.Red else Color.Green
+                Text(entry.message, color = color)
+            }
+        }
     }
 }
 

--- a/app/src/main/java/com/lnkv/nfcemulator/MainActivity.kt
+++ b/app/src/main/java/com/lnkv/nfcemulator/MainActivity.kt
@@ -11,6 +11,8 @@ import androidx.activity.enableEdgeToEdge
 import androidx.compose.material3.NavigationBar
 import androidx.compose.material3.NavigationBarItem
 import androidx.compose.material3.Text
+import androidx.compose.material3.Divider
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.saveable.rememberSaveable
@@ -123,7 +125,7 @@ fun CommunicationScreen(
             )
             Text("Incoming Communication")
         }
-        Spacer(modifier = Modifier.height(8.dp))
+        Spacer(modifier = Modifier.height(4.dp))
         Row(
             verticalAlignment = Alignment.CenterVertically,
             modifier = Modifier.fillMaxWidth().testTag("OutgoingToggle")
@@ -138,6 +140,13 @@ fun CommunicationScreen(
             Text("Outgoing Communication")
         }
 
+        Spacer(modifier = Modifier.height(4.dp))
+        Divider(
+            modifier = Modifier
+                .fillMaxWidth(0.9f)
+                .align(Alignment.CenterHorizontally)
+                .testTag("ToggleDivider")
+        )
         Spacer(modifier = Modifier.height(8.dp))
 
         val incomingEntries = entries.filter { it.isRequest }
@@ -195,11 +204,12 @@ private fun CommunicationLogList(
 ) {
     Column(modifier.fillMaxWidth()) {
         Text(label)
+        Spacer(modifier = Modifier.height(8.dp))
         Box(
             modifier = Modifier
                 .fillMaxSize()
                 .clip(RoundedCornerShape(8.dp))
-                .background(Color(0xFFE0E0E0))
+                .background(MaterialTheme.colorScheme.surfaceVariant)
                 .testTag(tag)
                 .padding(8.dp)
         ) {

--- a/app/src/main/java/com/lnkv/nfcemulator/MainActivity.kt
+++ b/app/src/main/java/com/lnkv/nfcemulator/MainActivity.kt
@@ -16,6 +16,12 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Button
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Nfc
+import androidx.compose.material.icons.filled.Wifi
+import androidx.compose.material.icons.filled.Settings
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.saveable.rememberSaveable
@@ -35,6 +41,8 @@ import androidx.compose.ui.platform.testTag
 import androidx.compose.foundation.background
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.platform.LocalContext
+import java.io.File
 import com.lnkv.nfcemulator.cardservice.TypeAEmulatorService
 import com.lnkv.nfcemulator.ui.theme.NFCEmulatorTheme
 
@@ -89,10 +97,10 @@ fun MainScreen() {
 
     androidx.compose.material3.Scaffold(
         topBar = {
-            TopAppBar(
+                TopAppBar(
                 modifier = Modifier.testTag("TopBar"),
                 colors = TopAppBarDefaults.topAppBarColors(containerColor = MaterialTheme.colorScheme.primary),
-                title = { Text(currentScreen.label, modifier = Modifier.testTag("ScreenHeader")) }
+                title = { Text(currentScreen.label.uppercase(), modifier = Modifier.testTag("ScreenHeader")) }
             )
         },
         bottomBar = {
@@ -101,7 +109,13 @@ fun MainScreen() {
                     NavigationBarItem(
                         selected = currentScreen == screen,
                         onClick = { currentScreen = screen },
-                        icon = { Box(modifier = Modifier.height(24.dp)) },
+                        icon = {
+                            when (screen) {
+                                Screen.Communication -> Icon(Icons.Filled.Nfc, contentDescription = screen.label)
+                                Screen.Server -> Icon(Icons.Filled.Wifi, contentDescription = screen.label)
+                                Screen.Settings -> Icon(Icons.Filled.Settings, contentDescription = screen.label)
+                            }
+                        },
                         label = { Text(screen.label) }
                     )
                 }
@@ -127,12 +141,11 @@ fun CommunicationScreen(
     var showServer by rememberSaveable { mutableStateOf(true) }
     var showNfc by rememberSaveable { mutableStateOf(true) }
 
-    Column(modifier = modifier.fillMaxSize().padding(vertical = 16.dp)) {
+    Column(modifier = modifier.fillMaxSize().padding(16.dp)) {
         Row(
             verticalAlignment = Alignment.CenterVertically,
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(horizontal = 16.dp)
                 .testTag("ServerToggle")
         ) {
             Checkbox(
@@ -140,8 +153,12 @@ fun CommunicationScreen(
                 onCheckedChange = { checked ->
                     if (!checked && !showNfc) return@Checkbox
                     showServer = checked
-                }
+                },
+                modifier = Modifier
+                    .offset(x = (-4).dp)
+                    .testTag("ServerCheck")
             )
+            Spacer(modifier = Modifier.width(8.dp))
             Text("Server Communication")
         }
         Spacer(modifier = Modifier.height(4.dp))
@@ -149,7 +166,6 @@ fun CommunicationScreen(
             verticalAlignment = Alignment.CenterVertically,
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(horizontal = 16.dp)
                 .testTag("NfcToggle")
         ) {
             Checkbox(
@@ -157,8 +173,12 @@ fun CommunicationScreen(
                 onCheckedChange = { checked ->
                     if (!checked && !showServer) return@Checkbox
                     showNfc = checked
-                }
+                },
+                modifier = Modifier
+                    .offset(x = (-4).dp)
+                    .testTag("NfcCheck")
             )
+            Spacer(modifier = Modifier.width(8.dp))
             Text("NFC Communication")
         }
 
@@ -166,7 +186,6 @@ fun CommunicationScreen(
         Divider(
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(horizontal = 16.dp)
                 .align(Alignment.CenterHorizontally)
                 .testTag("ToggleDivider")
         )
@@ -181,18 +200,14 @@ fun CommunicationScreen(
                     label = "Server Communication",
                     entries = serverEntries,
                     tag = "ServerLog",
-                    modifier = Modifier
-                        .weight(1f)
-                        .padding(horizontal = 16.dp)
+                    modifier = Modifier.weight(1f)
                 )
                 Spacer(modifier = Modifier.height(8.dp))
                 CommunicationLogList(
                     label = "NFC Communication",
                     entries = nfcEntries,
                     tag = "NfcLog",
-                    modifier = Modifier
-                        .weight(1f)
-                        .padding(horizontal = 16.dp)
+                    modifier = Modifier.weight(1f)
                 )
             }
             showServer -> {
@@ -200,9 +215,7 @@ fun CommunicationScreen(
                     label = "Server Communication",
                     entries = serverEntries,
                     tag = "ServerLog",
-                    modifier = Modifier
-                        .weight(1f)
-                        .padding(horizontal = 16.dp)
+                    modifier = Modifier.weight(1f)
                 )
             }
             showNfc -> {
@@ -210,11 +223,21 @@ fun CommunicationScreen(
                     label = "NFC Communication",
                     entries = nfcEntries,
                     tag = "NfcLog",
-                    modifier = Modifier
-                        .weight(1f)
-                        .padding(horizontal = 16.dp)
+                    modifier = Modifier.weight(1f)
                 )
             }
+        }
+
+        Spacer(modifier = Modifier.height(8.dp))
+        val context = LocalContext.current
+        Button(
+            onClick = {
+                val file = File(context.filesDir, "communication-log.txt")
+                CommunicationLog.saveToFile(file)
+            },
+            modifier = Modifier.align(Alignment.CenterHorizontally).testTag("SaveButton")
+        ) {
+            Text("Save Log File")
         }
     }
 }

--- a/app/src/main/java/com/lnkv/nfcemulator/MainActivity.kt
+++ b/app/src/main/java/com/lnkv/nfcemulator/MainActivity.kt
@@ -8,28 +8,37 @@ import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
-import androidx.compose.foundation.ScrollState
-import androidx.compose.foundation.layout.*
-import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.NavigationBar
+import androidx.compose.material3.NavigationBarItem
+import androidx.compose.material3.Text
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.runtime.collectAsState
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.graphics.Color
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
-import androidx.compose.material3.Button
 import androidx.compose.material3.Checkbox
-import androidx.compose.material3.Text
-import androidx.compose.material3.TextField
-import androidx.compose.runtime.*
-import androidx.compose.runtime.saveable.rememberSaveable
-import androidx.compose.ui.Alignment
-import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.unit.dp
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment.Companion.Center
 import com.lnkv.nfcemulator.cardservice.TypeAEmulatorService
 import com.lnkv.nfcemulator.ui.theme.NFCEmulatorTheme
 
 /**
- * Main activity displaying the UI for configuring emulated AIDs and
- * showing a log of APDU requests and responses.
+ * Main activity hosting a bottom navigation menu that switches between
+ * Communication, Server, and Settings screens.
  */
 class MainActivity : ComponentActivity() {
     private lateinit var cardEmulation: CardEmulation
@@ -39,119 +48,123 @@ class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()
-        // Set up references to the NFC subsystem and our emulation service
+
         val nfcAdapter = NfcAdapter.getDefaultAdapter(this)
         cardEmulation = CardEmulation.getInstance(nfcAdapter)
         componentName = ComponentName(this, TypeAEmulatorService::class.java)
         prefs = getSharedPreferences("nfc_aids", MODE_PRIVATE)
 
-        // Load and register previously stored AIDs
         val storedAids = prefs.getStringSet("aids", setOf("F0010203040506"))!!.toList()
         registerAids(storedAids)
 
         setContent {
             NFCEmulatorTheme {
-                var aid1 by rememberSaveable { mutableStateOf(storedAids.getOrNull(0) ?: "") }
-                var aid2 by rememberSaveable { mutableStateOf(storedAids.getOrNull(1) ?: "") }
-                var showAid1 by rememberSaveable { mutableStateOf(true) }
-                var showAid2 by rememberSaveable { mutableStateOf(true) }
-                val scrollState1 = rememberScrollState()
-                val scrollState2 = rememberScrollState()
+                var currentScreen by rememberSaveable { mutableStateOf(Screen.Communication) }
                 val logEntries by CommunicationLog.entries.collectAsState()
 
-                Column(
-                    modifier = Modifier
-                        .fillMaxSize()
-                        .padding(16.dp)
-                ) {
-                    // Toggle visibility for the first AID entry field
-                    Row(verticalAlignment = Alignment.CenterVertically) {
-                        Checkbox(
-                            checked = showAid1,
-                            onCheckedChange = { checked ->
-                                if (!checked && !showAid2) return@Checkbox
-                                showAid1 = checked
+                androidx.compose.material3.Scaffold(
+                    bottomBar = {
+                        NavigationBar {
+                            Screen.values().forEach { screen ->
+                                NavigationBarItem(
+                                    selected = currentScreen == screen,
+                                    onClick = { currentScreen = screen },
+                                    icon = { Box(modifier = Modifier.height(24.dp)) },
+                                    label = { Text(screen.label) }
+                                )
                             }
-                        )
-                        Text("Show AID 1")
-                    }
-                    if (showAid1) {
-                        ScrollableTextField(aid1, { aid1 = it }, scrollState1, "AID 1")
-                    }
-
-                    // Toggle visibility for the second AID entry field
-                    Row(verticalAlignment = Alignment.CenterVertically) {
-                        Checkbox(
-                            checked = showAid2,
-                            onCheckedChange = { checked ->
-                                if (!checked && !showAid1) return@Checkbox
-                                showAid2 = checked
-                            }
-                        )
-                        Text("Show AID 2")
-                    }
-                    if (showAid2) {
-                        ScrollableTextField(aid2, { aid2 = it }, scrollState2, "AID 2")
-                    }
-
-                    Spacer(modifier = Modifier.height(16.dp))
-                    Button(onClick = {
-                        // Gather visible AIDs and store them for future sessions
-                        val aids = mutableListOf<String>()
-                        if (showAid1 && aid1.isNotBlank()) aids.add(aid1)
-                        if (showAid2 && aid2.isNotBlank()) aids.add(aid2)
-                        registerAids(aids)
-                        prefs.edit().putStringSet("aids", aids.toSet()).apply()
-                    }) {
-                        Text("Save AIDs")
-                    }
-
-                    Spacer(modifier = Modifier.height(16.dp))
-                    Text("Communication Log")
-                    LazyColumn(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .weight(1f)
-                    ) {
-                        // Display APDU exchanges, color-coded by direction
-                        items(logEntries) { entry ->
-                            Text(
-                                text = entry.message,
-                                color = if (entry.isRequest) Color.Red else Color.Green
-                            )
                         }
+                    }
+                ) { padding ->
+                    when (currentScreen) {
+                        Screen.Communication ->
+                            CommunicationScreen(logEntries, Modifier.padding(padding))
+                        Screen.Server ->
+                            PlaceholderScreen("Server", Modifier.padding(padding))
+                        Screen.Settings ->
+                            PlaceholderScreen("Settings", Modifier.padding(padding))
                     }
                 }
             }
         }
     }
 
-    /**
-     * Registers the given AIDs with Android's card emulation system so
-     * APDU commands targeting them are routed to our service.
-     */
     private fun registerAids(aids: List<String>) {
-        cardEmulation.registerAidsForService(componentName, CardEmulation.CATEGORY_OTHER, aids)
+        cardEmulation.registerAidsForService(
+            componentName,
+            CardEmulation.CATEGORY_OTHER,
+            aids
+        )
     }
 }
-/**
- * Text field used for entering long hexadecimal AIDs. It enables vertical
- * scrolling so the user can review and edit the entire value.
- */
-@Composable
-private fun ScrollableTextField(
-    value: String,
-    onValueChange: (String) -> Unit,
-    scrollState: ScrollState,
-    label: String
-) {
-    TextField(
-        value = value,
-        onValueChange = onValueChange,
-        modifier = Modifier
-            .fillMaxWidth()
-            .height(120.dp)
-            .verticalScroll(scrollState),
-        label = { Text(label) }
-    )
+
+enum class Screen(val label: String) {
+    Communication("Communication"),
+    Server("Server"),
+    Settings("Settings")
 }
+
+@Composable
+fun CommunicationScreen(
+    entries: List<CommunicationLog.Entry>,
+    modifier: Modifier = Modifier
+) {
+    var showIncoming by rememberSaveable { mutableStateOf(true) }
+    var showOutgoing by rememberSaveable { mutableStateOf(true) }
+
+    Column(modifier = modifier.fillMaxSize().padding(16.dp)) {
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            Checkbox(
+                checked = showIncoming,
+                onCheckedChange = { checked ->
+                    if (!checked && !showOutgoing) return@Checkbox
+                    showIncoming = checked
+                }
+            )
+            Text("Show Incoming Communication")
+        }
+        if (showIncoming) {
+            LazyColumn(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .weight(1f)
+            ) {
+                items(entries.filter { it.isRequest }) { entry ->
+                    Text(entry.message, color = Color.Red)
+                }
+            }
+        }
+
+        Spacer(modifier = Modifier.height(8.dp))
+
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            Checkbox(
+                checked = showOutgoing,
+                onCheckedChange = { checked ->
+                    if (!checked && !showIncoming) return@Checkbox
+                    showOutgoing = checked
+                }
+            )
+            Text("Show Outgoing Communication")
+        }
+        if (showOutgoing) {
+            LazyColumn(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .weight(1f)
+            ) {
+                items(entries.filter { !it.isRequest }) { entry ->
+                    Text(entry.message, color = Color.Green)
+                }
+            }
+        }
+    }
+}
+
+@Composable
+fun PlaceholderScreen(text: String, modifier: Modifier = Modifier) {
+    Box(modifier = modifier.fillMaxSize(), contentAlignment = Center) {
+        Text(text)
+    }
+}
+

--- a/app/src/main/java/com/lnkv/nfcemulator/MainActivity.kt
+++ b/app/src/main/java/com/lnkv/nfcemulator/MainActivity.kt
@@ -11,7 +11,7 @@ import androidx.activity.enableEdgeToEdge
 import androidx.compose.material3.NavigationBar
 import androidx.compose.material3.NavigationBarItem
 import androidx.compose.material3.Text
-import androidx.compose.material3.Divider
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
@@ -83,6 +83,9 @@ class MainActivity : ComponentActivity() {
     }
 }
 
+/**
+ * Navigation targets displayed in the bottom bar.
+ */
 enum class Screen(val label: String) {
     Communication("Communication"),
     Server("Server"),
@@ -133,6 +136,11 @@ fun MainScreen() {
     }
 }
 
+/**
+ * UI for monitoring APDU traffic. Two toggles control visibility of
+ * server (incoming) and NFC (outgoing) streams while the logs expand to
+ * fill available space when shown individually.
+ */
 @Composable
 fun CommunicationScreen(
     entries: List<CommunicationLog.Entry>,
@@ -158,7 +166,7 @@ fun CommunicationScreen(
                     .offset(x = (-4).dp)
                     .testTag("ServerCheck")
             )
-            Spacer(modifier = Modifier.width(8.dp))
+            Spacer(modifier = Modifier.width(4.dp))
             Text("Server Communication")
         }
         Spacer(modifier = Modifier.height(4.dp))
@@ -178,12 +186,12 @@ fun CommunicationScreen(
                     .offset(x = (-4).dp)
                     .testTag("NfcCheck")
             )
-            Spacer(modifier = Modifier.width(8.dp))
+            Spacer(modifier = Modifier.width(4.dp))
             Text("NFC Communication")
         }
 
         Spacer(modifier = Modifier.height(4.dp))
-        Divider(
+        HorizontalDivider(
             modifier = Modifier
                 .fillMaxWidth()
                 .align(Alignment.CenterHorizontally)
@@ -230,18 +238,25 @@ fun CommunicationScreen(
 
         Spacer(modifier = Modifier.height(8.dp))
         val context = LocalContext.current
+        // Persist the current communication log to a text file in the app's
+        // internal storage so users can share or inspect the raw APDU stream.
         Button(
             onClick = {
                 val file = File(context.filesDir, "communication-log.txt")
                 CommunicationLog.saveToFile(file)
             },
-            modifier = Modifier.align(Alignment.CenterHorizontally).testTag("SaveButton")
+            modifier = Modifier
+                .fillMaxWidth()
+                .testTag("SaveButton")
         ) {
             Text("Save Log File")
         }
     }
 }
 
+/**
+ * Simple placeholder used for sections that are not yet implemented.
+ */
 @Composable
 fun PlaceholderScreen(text: String, modifier: Modifier = Modifier) {
     Box(modifier = modifier.fillMaxSize(), contentAlignment = Center) {
@@ -249,6 +264,10 @@ fun PlaceholderScreen(text: String, modifier: Modifier = Modifier) {
     }
 }
 
+/**
+ * Renders a labeled list of communication log [entries]. Each list item is
+ * colored red for requests and green for responses.
+ */
 @Composable
 private fun CommunicationLogList(
     label: String,

--- a/app/src/main/java/com/lnkv/nfcemulator/MainActivity.kt
+++ b/app/src/main/java/com/lnkv/nfcemulator/MainActivity.kt
@@ -14,6 +14,7 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.Divider
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.saveable.rememberSaveable
@@ -79,6 +80,7 @@ enum class Screen(val label: String) {
     Settings("Settings")
 }
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun MainScreen() {
     var currentScreen by rememberSaveable { mutableStateOf(Screen.Communication) }

--- a/app/src/main/java/com/lnkv/nfcemulator/MainActivity.kt
+++ b/app/src/main/java/com/lnkv/nfcemulator/MainActivity.kt
@@ -27,6 +27,9 @@ import androidx.compose.material3.Checkbox
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment.Companion.Center
 import androidx.compose.ui.platform.testTag
+import androidx.compose.foundation.background
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.ui.draw.clip
 import com.lnkv.nfcemulator.cardservice.TypeAEmulatorService
 import com.lnkv.nfcemulator.ui.theme.NFCEmulatorTheme
 
@@ -107,7 +110,10 @@ fun CommunicationScreen(
     var showOutgoing by rememberSaveable { mutableStateOf(true) }
 
     Column(modifier = modifier.fillMaxSize().padding(16.dp)) {
-        Row(verticalAlignment = Alignment.CenterVertically) {
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            modifier = Modifier.fillMaxWidth().testTag("IncomingToggle")
+        ) {
             Checkbox(
                 checked = showIncoming,
                 onCheckedChange = { checked ->
@@ -115,10 +121,13 @@ fun CommunicationScreen(
                     showIncoming = checked
                 }
             )
-            Text("Show Incoming Communication")
+            Text("Incoming Communication")
         }
         Spacer(modifier = Modifier.height(8.dp))
-        Row(verticalAlignment = Alignment.CenterVertically) {
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            modifier = Modifier.fillMaxWidth().testTag("OutgoingToggle")
+        ) {
             Checkbox(
                 checked = showOutgoing,
                 onCheckedChange = { checked ->
@@ -126,7 +135,7 @@ fun CommunicationScreen(
                     showOutgoing = checked
                 }
             )
-            Text("Show Outgoing Communication")
+            Text("Outgoing Communication")
         }
 
         Spacer(modifier = Modifier.height(8.dp))
@@ -186,14 +195,19 @@ private fun CommunicationLogList(
 ) {
     Column(modifier.fillMaxWidth()) {
         Text(label)
-        LazyColumn(
+        Box(
             modifier = Modifier
                 .fillMaxSize()
+                .clip(RoundedCornerShape(8.dp))
+                .background(Color(0xFFE0E0E0))
                 .testTag(tag)
+                .padding(8.dp)
         ) {
-            items(entries) { entry ->
-                val color = if (entry.isRequest) Color.Red else Color.Green
-                Text(entry.message, color = color)
+            LazyColumn(modifier = Modifier.fillMaxSize()) {
+                items(entries) { entry ->
+                    val color = if (entry.isRequest) Color.Red else Color.Green
+                    Text(entry.message, color = color)
+                }
             }
         }
     }

--- a/app/src/test/java/com/lnkv/nfcemulator/CommunicationLogTest.kt
+++ b/app/src/test/java/com/lnkv/nfcemulator/CommunicationLogTest.kt
@@ -1,0 +1,32 @@
+package com.lnkv.nfcemulator
+
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+
+/**
+ * Unit tests for [CommunicationLog].
+ */
+class CommunicationLogTest {
+
+    @Before
+    fun setUp() {
+        CommunicationLog.clear()
+    }
+
+    @Test
+    fun addAppendsEntry() {
+        CommunicationLog.add("DATA", true)
+        val entries = CommunicationLog.entries.value
+        assertEquals(1, entries.size)
+        assertEquals(CommunicationLog.Entry("DATA", true), entries[0])
+    }
+
+    @Test
+    fun clearRemovesAllEntries() {
+        CommunicationLog.add("ONE", true)
+        CommunicationLog.add("TWO", false)
+        CommunicationLog.clear()
+        assertEquals(0, CommunicationLog.entries.value.size)
+    }
+}

--- a/app/src/test/java/com/lnkv/nfcemulator/CommunicationLogTest.kt
+++ b/app/src/test/java/com/lnkv/nfcemulator/CommunicationLogTest.kt
@@ -3,6 +3,7 @@ package com.lnkv.nfcemulator
 import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
+import kotlin.io.path.createTempFile
 
 /**
  * Unit tests for [CommunicationLog].
@@ -28,5 +29,15 @@ class CommunicationLogTest {
         CommunicationLog.add("TWO", false)
         CommunicationLog.clear()
         assertEquals(0, CommunicationLog.entries.value.size)
+    }
+
+    @Test
+    fun saveToFileWritesMessages() {
+        CommunicationLog.add("ONE", true)
+        CommunicationLog.add("TWO", false)
+        val file = kotlin.io.path.createTempFile().toFile()
+        CommunicationLog.saveToFile(file)
+        val lines = file.readLines()
+        assertEquals(listOf("ONE", "TWO"), lines)
     }
 }

--- a/app/src/test/java/com/lnkv/nfcemulator/CommunicationScreenTest.kt
+++ b/app/src/test/java/com/lnkv/nfcemulator/CommunicationScreenTest.kt
@@ -2,9 +2,11 @@ package com.lnkv.nfcemulator
 
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.*
+import androidx.compose.ui.unit.dp
 import org.junit.Rule
 import org.junit.Test
 import kotlin.test.assertTrue
+import kotlin.test.assertEquals
 
 class CommunicationScreenTest {
 
@@ -38,11 +40,25 @@ class CommunicationScreenTest {
         }
 
         val heightBoth = composeTestRule.onNodeWithTag("IncomingLog").fetchSemanticsNode().size.height
-        composeTestRule.onNodeWithText("Show Outgoing Communication").performClick()
+        composeTestRule.onNodeWithText("Outgoing Communication").performClick()
         composeTestRule.waitForIdle()
         val heightSingle = composeTestRule.onNodeWithTag("IncomingLog").fetchSemanticsNode().size.height
         assertTrue(heightSingle > heightBoth)
         composeTestRule.onNodeWithText("A1B2").assertDoesNotExist()
+    }
+
+    @Test
+    fun toggleRowsFillWidth() {
+        composeTestRule.setContent { CommunicationScreen(emptyList()) }
+
+        val rootWidth = composeTestRule.onRoot().fetchSemanticsNode().size.width
+        val expectedWidth = rootWidth - with(composeTestRule.density) { 32.dp.roundToPx() }
+
+        val incomingWidth = composeTestRule.onNodeWithTag("IncomingToggle").fetchSemanticsNode().size.width
+        val outgoingWidth = composeTestRule.onNodeWithTag("OutgoingToggle").fetchSemanticsNode().size.width
+
+        assertEquals(expectedWidth, incomingWidth)
+        assertEquals(expectedWidth, outgoingWidth)
     }
 }
 

--- a/app/src/test/java/com/lnkv/nfcemulator/CommunicationScreenTest.kt
+++ b/app/src/test/java/com/lnkv/nfcemulator/CommunicationScreenTest.kt
@@ -1,0 +1,28 @@
+package com.lnkv.nfcemulator
+
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import org.junit.Rule
+import org.junit.Test
+
+class CommunicationScreenTest {
+
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    @Test
+    fun showsIncomingAndOutgoingMessages() {
+        val entries = listOf(
+            CommunicationLog.Entry("0102", true),
+            CommunicationLog.Entry("A1B2", false)
+        )
+
+        composeTestRule.setContent {
+            CommunicationScreen(entries)
+        }
+
+        composeTestRule.onNodeWithText("0102").assertExists()
+        composeTestRule.onNodeWithText("A1B2").assertExists()
+    }
+}
+

--- a/app/src/test/java/com/lnkv/nfcemulator/CommunicationScreenTest.kt
+++ b/app/src/test/java/com/lnkv/nfcemulator/CommunicationScreenTest.kt
@@ -7,7 +7,6 @@ import org.junit.Rule
 import org.junit.Test
 import kotlin.test.assertTrue
 import kotlin.test.assertEquals
-import kotlin.math.roundToInt
 
 class CommunicationScreenTest {
 
@@ -15,7 +14,7 @@ class CommunicationScreenTest {
     val composeTestRule = createComposeRule()
 
     @Test
-    fun showsIncomingAndOutgoingMessages() {
+    fun showsServerAndNfcMessages() {
         val entries = listOf(
             CommunicationLog.Entry("0102", true),
             CommunicationLog.Entry("A1B2", false)
@@ -30,7 +29,7 @@ class CommunicationScreenTest {
     }
 
     @Test
-    fun incomingExpandsWhenOutgoingHidden() {
+    fun serverExpandsWhenNfcHidden() {
         val entries = listOf(
             CommunicationLog.Entry("0102", true),
             CommunicationLog.Entry("A1B2", false)
@@ -40,10 +39,10 @@ class CommunicationScreenTest {
             CommunicationScreen(entries)
         }
 
-        val heightBoth = composeTestRule.onNodeWithTag("IncomingLog").fetchSemanticsNode().size.height
-        composeTestRule.onNodeWithText("Outgoing Communication").performClick()
+        val heightBoth = composeTestRule.onNodeWithTag("ServerLog").fetchSemanticsNode().size.height
+        composeTestRule.onNodeWithText("NFC Communication").performClick()
         composeTestRule.waitForIdle()
-        val heightSingle = composeTestRule.onNodeWithTag("IncomingLog").fetchSemanticsNode().size.height
+        val heightSingle = composeTestRule.onNodeWithTag("ServerLog").fetchSemanticsNode().size.height
         assertTrue(heightSingle > heightBoth)
         composeTestRule.onNodeWithText("A1B2").assertDoesNotExist()
     }
@@ -55,24 +54,21 @@ class CommunicationScreenTest {
         val rootWidth = composeTestRule.onRoot().fetchSemanticsNode().size.width
         val expectedWidth = rootWidth - with(composeTestRule.density) { 32.dp.roundToPx() }
 
-        val incomingWidth = composeTestRule.onNodeWithTag("IncomingToggle").fetchSemanticsNode().size.width
-        val outgoingWidth = composeTestRule.onNodeWithTag("OutgoingToggle").fetchSemanticsNode().size.width
+        val serverWidth = composeTestRule.onNodeWithTag("ServerToggle").fetchSemanticsNode().size.width
+        val nfcWidth = composeTestRule.onNodeWithTag("NfcToggle").fetchSemanticsNode().size.width
 
-        assertEquals(expectedWidth, incomingWidth)
-        assertEquals(expectedWidth, outgoingWidth)
+        assertEquals(expectedWidth, serverWidth)
+        assertEquals(expectedWidth, nfcWidth)
     }
 
     @Test
-    fun dividerSpansNinetyPercentWidth() {
+    fun dividerMatchesLogWidth() {
         composeTestRule.setContent { CommunicationScreen(emptyList()) }
 
-        val rootWidth = composeTestRule.onRoot().fetchSemanticsNode().size.width
-        val contentWidth = rootWidth - with(composeTestRule.density) { 32.dp.roundToPx() }
-        val expectedWidth = (contentWidth * 0.9f).roundToInt()
-
+        val logWidth = composeTestRule.onNodeWithTag("ServerLog").fetchSemanticsNode().size.width
         val dividerWidth = composeTestRule.onNodeWithTag("ToggleDivider").fetchSemanticsNode().size.width
 
-        assertEquals(expectedWidth, dividerWidth)
+        assertEquals(logWidth, dividerWidth)
     }
 }
 

--- a/app/src/test/java/com/lnkv/nfcemulator/CommunicationScreenTest.kt
+++ b/app/src/test/java/com/lnkv/nfcemulator/CommunicationScreenTest.kt
@@ -74,21 +74,30 @@ class CommunicationScreenTest {
     @Test
     fun togglesAlignWithLogs() {
         composeTestRule.setContent { CommunicationScreen(emptyList()) }
-
-        val serverCheckX = composeTestRule.onNodeWithTag("ServerCheck").fetchSemanticsNode().positionInRoot.x
+        val serverToggleX = composeTestRule.onNodeWithTag("ServerToggle").fetchSemanticsNode().positionInRoot.x
         val serverLogX = composeTestRule.onNodeWithTag("ServerLog").fetchSemanticsNode().positionInRoot.x
 
-        val nfcCheckX = composeTestRule.onNodeWithTag("NfcCheck").fetchSemanticsNode().positionInRoot.x
+        val nfcToggleX = composeTestRule.onNodeWithTag("NfcToggle").fetchSemanticsNode().positionInRoot.x
         val nfcLogX = composeTestRule.onNodeWithTag("NfcLog").fetchSemanticsNode().positionInRoot.x
 
-        assertEquals(serverLogX, serverCheckX)
-        assertEquals(nfcLogX, nfcCheckX)
+        assertEquals(serverLogX, serverToggleX)
+        assertEquals(nfcLogX, nfcToggleX)
     }
 
     @Test
     fun saveButtonIsDisplayed() {
         composeTestRule.setContent { CommunicationScreen(emptyList()) }
         composeTestRule.onNodeWithTag("SaveButton").assertExists()
+    }
+
+    @Test
+    fun saveButtonMatchesLogWidth() {
+        composeTestRule.setContent { CommunicationScreen(emptyList()) }
+
+        val logWidth = composeTestRule.onNodeWithTag("ServerLog").fetchSemanticsNode().size.width
+        val buttonWidth = composeTestRule.onNodeWithTag("SaveButton").fetchSemanticsNode().size.width
+
+        assertEquals(logWidth, buttonWidth)
     }
 }
 

--- a/app/src/test/java/com/lnkv/nfcemulator/CommunicationScreenTest.kt
+++ b/app/src/test/java/com/lnkv/nfcemulator/CommunicationScreenTest.kt
@@ -70,5 +70,19 @@ class CommunicationScreenTest {
 
         assertEquals(logWidth, dividerWidth)
     }
+
+    @Test
+    fun togglesAlignWithLogs() {
+        composeTestRule.setContent { CommunicationScreen(emptyList()) }
+
+        val serverToggleX = composeTestRule.onNodeWithTag("ServerToggle").fetchSemanticsNode().positionInRoot.x
+        val serverLogX = composeTestRule.onNodeWithTag("ServerLog").fetchSemanticsNode().positionInRoot.x
+
+        val nfcToggleX = composeTestRule.onNodeWithTag("NfcToggle").fetchSemanticsNode().positionInRoot.x
+        val nfcLogX = composeTestRule.onNodeWithTag("NfcLog").fetchSemanticsNode().positionInRoot.x
+
+        assertEquals(serverLogX, serverToggleX)
+        assertEquals(nfcLogX, nfcToggleX)
+    }
 }
 

--- a/app/src/test/java/com/lnkv/nfcemulator/CommunicationScreenTest.kt
+++ b/app/src/test/java/com/lnkv/nfcemulator/CommunicationScreenTest.kt
@@ -7,6 +7,7 @@ import org.junit.Rule
 import org.junit.Test
 import kotlin.test.assertTrue
 import kotlin.test.assertEquals
+import kotlin.math.roundToInt
 
 class CommunicationScreenTest {
 
@@ -59,6 +60,19 @@ class CommunicationScreenTest {
 
         assertEquals(expectedWidth, incomingWidth)
         assertEquals(expectedWidth, outgoingWidth)
+    }
+
+    @Test
+    fun dividerSpansNinetyPercentWidth() {
+        composeTestRule.setContent { CommunicationScreen(emptyList()) }
+
+        val rootWidth = composeTestRule.onRoot().fetchSemanticsNode().size.width
+        val contentWidth = rootWidth - with(composeTestRule.density) { 32.dp.roundToPx() }
+        val expectedWidth = (contentWidth * 0.9f).roundToInt()
+
+        val dividerWidth = composeTestRule.onNodeWithTag("ToggleDivider").fetchSemanticsNode().size.width
+
+        assertEquals(expectedWidth, dividerWidth)
     }
 }
 

--- a/app/src/test/java/com/lnkv/nfcemulator/CommunicationScreenTest.kt
+++ b/app/src/test/java/com/lnkv/nfcemulator/CommunicationScreenTest.kt
@@ -1,9 +1,10 @@
 package com.lnkv.nfcemulator
 
 import androidx.compose.ui.test.junit4.createComposeRule
-import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.*
 import org.junit.Rule
 import org.junit.Test
+import kotlin.test.assertTrue
 
 class CommunicationScreenTest {
 
@@ -23,6 +24,25 @@ class CommunicationScreenTest {
 
         composeTestRule.onNodeWithText("0102").assertExists()
         composeTestRule.onNodeWithText("A1B2").assertExists()
+    }
+
+    @Test
+    fun incomingExpandsWhenOutgoingHidden() {
+        val entries = listOf(
+            CommunicationLog.Entry("0102", true),
+            CommunicationLog.Entry("A1B2", false)
+        )
+
+        composeTestRule.setContent {
+            CommunicationScreen(entries)
+        }
+
+        val heightBoth = composeTestRule.onNodeWithTag("IncomingLog").fetchSemanticsNode().size.height
+        composeTestRule.onNodeWithText("Show Outgoing Communication").performClick()
+        composeTestRule.waitForIdle()
+        val heightSingle = composeTestRule.onNodeWithTag("IncomingLog").fetchSemanticsNode().size.height
+        assertTrue(heightSingle > heightBoth)
+        composeTestRule.onNodeWithText("A1B2").assertDoesNotExist()
     }
 }
 

--- a/app/src/test/java/com/lnkv/nfcemulator/CommunicationScreenTest.kt
+++ b/app/src/test/java/com/lnkv/nfcemulator/CommunicationScreenTest.kt
@@ -75,14 +75,20 @@ class CommunicationScreenTest {
     fun togglesAlignWithLogs() {
         composeTestRule.setContent { CommunicationScreen(emptyList()) }
 
-        val serverToggleX = composeTestRule.onNodeWithTag("ServerToggle").fetchSemanticsNode().positionInRoot.x
+        val serverCheckX = composeTestRule.onNodeWithTag("ServerCheck").fetchSemanticsNode().positionInRoot.x
         val serverLogX = composeTestRule.onNodeWithTag("ServerLog").fetchSemanticsNode().positionInRoot.x
 
-        val nfcToggleX = composeTestRule.onNodeWithTag("NfcToggle").fetchSemanticsNode().positionInRoot.x
+        val nfcCheckX = composeTestRule.onNodeWithTag("NfcCheck").fetchSemanticsNode().positionInRoot.x
         val nfcLogX = composeTestRule.onNodeWithTag("NfcLog").fetchSemanticsNode().positionInRoot.x
 
-        assertEquals(serverLogX, serverToggleX)
-        assertEquals(nfcLogX, nfcToggleX)
+        assertEquals(serverLogX, serverCheckX)
+        assertEquals(nfcLogX, nfcCheckX)
+    }
+
+    @Test
+    fun saveButtonIsDisplayed() {
+        composeTestRule.setContent { CommunicationScreen(emptyList()) }
+        composeTestRule.onNodeWithTag("SaveButton").assertExists()
     }
 }
 

--- a/app/src/test/java/com/lnkv/nfcemulator/MainScreenTest.kt
+++ b/app/src/test/java/com/lnkv/nfcemulator/MainScreenTest.kt
@@ -1,0 +1,27 @@
+package com.lnkv.nfcemulator
+
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import org.junit.Rule
+import org.junit.Test
+
+class MainScreenTest {
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    @Test
+    fun headerUpdatesWithNavigation() {
+        composeTestRule.setContent { MainScreen() }
+
+        composeTestRule.onNodeWithTag("ScreenHeader").assertExists()
+        composeTestRule.onNodeWithTag("ScreenHeader").assertTextEquals("Communication")
+
+        composeTestRule.onNodeWithText("Server").performClick()
+        composeTestRule.onNodeWithTag("ScreenHeader").assertTextEquals("Server")
+
+        composeTestRule.onNodeWithText("Settings").performClick()
+        composeTestRule.onNodeWithTag("ScreenHeader").assertTextEquals("Settings")
+    }
+}

--- a/app/src/test/java/com/lnkv/nfcemulator/MainScreenTest.kt
+++ b/app/src/test/java/com/lnkv/nfcemulator/MainScreenTest.kt
@@ -1,11 +1,18 @@
 package com.lnkv.nfcemulator
 
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.toArgb
+import androidx.compose.ui.graphics.toPixelMap
+import androidx.compose.ui.test.captureToImage
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
+import androidx.compose.material3.MaterialTheme
 import org.junit.Rule
 import org.junit.Test
+import kotlin.test.assertEquals
+import com.lnkv.nfcemulator.ui.theme.NFCEmulatorTheme
 
 class MainScreenTest {
     @get:Rule
@@ -23,5 +30,20 @@ class MainScreenTest {
 
         composeTestRule.onNodeWithText("Settings").performClick()
         composeTestRule.onNodeWithTag("ScreenHeader").assertTextEquals("Settings")
+    }
+
+    @Test
+    fun topBarUsesPrimaryColor() {
+        var expected = Color.Unspecified
+        composeTestRule.setContent {
+            NFCEmulatorTheme {
+                expected = MaterialTheme.colorScheme.primary
+                MainScreen()
+            }
+        }
+
+        val image = composeTestRule.onNodeWithTag("TopBar").captureToImage()
+        val actual = image.toPixelMap()[0, 0]
+        assertEquals(expected.toArgb(), actual.toArgb())
     }
 }

--- a/app/src/test/java/com/lnkv/nfcemulator/MainScreenTest.kt
+++ b/app/src/test/java/com/lnkv/nfcemulator/MainScreenTest.kt
@@ -8,6 +8,7 @@ import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.material3.MaterialTheme
 import org.junit.Rule
 import org.junit.Test
@@ -23,13 +24,13 @@ class MainScreenTest {
         composeTestRule.setContent { MainScreen() }
 
         composeTestRule.onNodeWithTag("ScreenHeader").assertExists()
-        composeTestRule.onNodeWithTag("ScreenHeader").assertTextEquals("Communication")
+        composeTestRule.onNodeWithTag("ScreenHeader").assertTextEquals("COMMUNICATION")
 
         composeTestRule.onNodeWithText("Server").performClick()
-        composeTestRule.onNodeWithTag("ScreenHeader").assertTextEquals("Server")
+        composeTestRule.onNodeWithTag("ScreenHeader").assertTextEquals("SERVER")
 
         composeTestRule.onNodeWithText("Settings").performClick()
-        composeTestRule.onNodeWithTag("ScreenHeader").assertTextEquals("Settings")
+        composeTestRule.onNodeWithTag("ScreenHeader").assertTextEquals("SETTINGS")
     }
 
     @Test
@@ -45,5 +46,13 @@ class MainScreenTest {
         val image = composeTestRule.onNodeWithTag("TopBar").captureToImage()
         val actual = image.toPixelMap()[0, 0]
         assertEquals(expected.toArgb(), actual.toArgb())
+    }
+
+    @Test
+    fun navigationIconsPresent() {
+        composeTestRule.setContent { MainScreen() }
+        composeTestRule.onNodeWithContentDescription("Communication").assertExists()
+        composeTestRule.onNodeWithContentDescription("Server").assertExists()
+        composeTestRule.onNodeWithContentDescription("Settings").assertExists()
     }
 }

--- a/app/src/test/java/com/lnkv/nfcemulator/cardservice/TypeAEmulatorServiceTest.kt
+++ b/app/src/test/java/com/lnkv/nfcemulator/cardservice/TypeAEmulatorServiceTest.kt
@@ -1,0 +1,42 @@
+package com.lnkv.nfcemulator.cardservice
+
+import com.lnkv.nfcemulator.CommunicationLog
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+
+/**
+ * Tests for [TypeAEmulatorService].
+ */
+class TypeAEmulatorServiceTest {
+
+    private lateinit var service: TypeAEmulatorService
+
+    @Before
+    fun setUp() {
+        service = TypeAEmulatorService()
+        CommunicationLog.clear()
+    }
+
+    @Test
+    fun processCommandApdu_select_returnsSuccessAndLogs() {
+        val select = byteArrayOf(0x00, 0xA4.toByte(), 0x04, 0x00)
+        val response = service.processCommandApdu(select, null)
+
+        assertArrayEquals(byteArrayOf(0x90.toByte(), 0x00.toByte()), response)
+        val entries = CommunicationLog.entries.value
+        assertEquals("REQ: 00A40400", entries[0].message)
+        assertEquals(true, entries[0].isRequest)
+        assertEquals("RESP: 9000", entries[1].message)
+        assertEquals(false, entries[1].isRequest)
+    }
+
+    @Test
+    fun processCommandApdu_unknown_returnsError() {
+        val command = byteArrayOf(0x00, 0xB0.toByte(), 0x00, 0x00)
+        val response = service.processCommandApdu(command, null)
+
+        assertArrayEquals(byteArrayOf(0x6A.toByte(), 0x82.toByte()), response)
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -25,6 +25,7 @@ androidx-ui-test-manifest = { group = "androidx.compose.ui", name = "ui-test-man
 androidx-ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-test-junit4" }
 androidx-material3 = { group = "androidx.compose.material3", name = "material3" }
 androidx-runtime-saveable = { group = "androidx.compose.runtime", name = "runtime-saveable" }
+androidx-material-icons-extended = { group = "androidx.compose.material", name = "material-icons-extended" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -24,6 +24,7 @@ androidx-ui-tooling-preview = { group = "androidx.compose.ui", name = "ui-toolin
 androidx-ui-test-manifest = { group = "androidx.compose.ui", name = "ui-test-manifest" }
 androidx-ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-test-junit4" }
 androidx-material3 = { group = "androidx.compose.material3", name = "material3" }
+androidx-runtime-saveable = { group = "androidx.compose.runtime", name = "runtime-saveable" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
## Summary
- replace AID entry screen with a communication view that separates incoming and outgoing logs
- add bottom navigation with Communication, Server, and Settings placeholders
- add Compose unit test for Communication screen

## Testing
- `bash gradlew test` *(fails: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_68a0593920408330a2daaae654b99420