### PR TITLE
Disable lone communication log toggle

### DIFF
--- a/app/src/main/java/com/lnkv/nfcemulator/MainActivity.kt
+++ b/app/src/main/java/com/lnkv/nfcemulator/MainActivity.kt
@@ -35,6 +35,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material3.Checkbox
+import androidx.compose.material3.CheckboxDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment.Companion.Center
 import androidx.compose.ui.platform.testTag
@@ -154,39 +155,55 @@ fun CommunicationScreen(
             verticalAlignment = Alignment.CenterVertically,
             modifier = Modifier
                 .fillMaxWidth()
+                .clip(RoundedCornerShape(12.dp))
+                .background(MaterialTheme.colorScheme.surfaceVariant)
+                .padding(horizontal = 12.dp, vertical = 8.dp)
                 .testTag("ServerToggle")
         ) {
             Checkbox(
                 checked = showServer,
                 onCheckedChange = { showServer = it },
                 enabled = showNfc || !showServer,
-                modifier = Modifier
-                    .offset(x = (-4).dp)
-                    .testTag("ServerCheck")
+                colors = CheckboxDefaults.colors(
+                    checkedColor = MaterialTheme.colorScheme.primary,
+                    uncheckedColor = MaterialTheme.colorScheme.outline,
+                    checkmarkColor = MaterialTheme.colorScheme.onPrimary,
+                    disabledCheckedColor = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.6f),
+                    disabledUncheckedColor = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.6f)
+                ),
+                modifier = Modifier.testTag("ServerCheck")
             )
-            Spacer(modifier = Modifier.width(4.dp))
-            Text("Server Communication")
+            Spacer(modifier = Modifier.width(8.dp))
+            Text("Server Communication", style = MaterialTheme.typography.bodyLarge)
         }
-        Spacer(modifier = Modifier.height(4.dp))
+        Spacer(modifier = Modifier.height(8.dp))
         Row(
             verticalAlignment = Alignment.CenterVertically,
             modifier = Modifier
                 .fillMaxWidth()
+                .clip(RoundedCornerShape(12.dp))
+                .background(MaterialTheme.colorScheme.surfaceVariant)
+                .padding(horizontal = 12.dp, vertical = 8.dp)
                 .testTag("NfcToggle")
         ) {
             Checkbox(
                 checked = showNfc,
                 onCheckedChange = { showNfc = it },
                 enabled = showServer || !showNfc,
-                modifier = Modifier
-                    .offset(x = (-4).dp)
-                    .testTag("NfcCheck")
+                colors = CheckboxDefaults.colors(
+                    checkedColor = MaterialTheme.colorScheme.primary,
+                    uncheckedColor = MaterialTheme.colorScheme.outline,
+                    checkmarkColor = MaterialTheme.colorScheme.onPrimary,
+                    disabledCheckedColor = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.6f),
+                    disabledUncheckedColor = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.6f)
+                ),
+                modifier = Modifier.testTag("NfcCheck")
             )
-            Spacer(modifier = Modifier.width(4.dp))
-            Text("NFC Communication")
+            Spacer(modifier = Modifier.width(8.dp))
+            Text("NFC Communication", style = MaterialTheme.typography.bodyLarge)
         }
 
-        Spacer(modifier = Modifier.height(4.dp))
+        Spacer(modifier = Modifier.height(8.dp))
         HorizontalDivider(
             modifier = Modifier
                 .fillMaxWidth()

--- a/app/src/main/java/com/lnkv/nfcemulator/MainActivity.kt
+++ b/app/src/main/java/com/lnkv/nfcemulator/MainActivity.kt
@@ -278,22 +278,31 @@ fun ScenarioScreen(modifier: Modifier = Modifier) {
     var selectedIndex by rememberSaveable { mutableStateOf<Int?>(null) }
 
     Column(modifier = modifier.fillMaxSize().padding(16.dp)) {
-        LazyColumn(modifier = Modifier.weight(1f)) {
-            itemsIndexed(scenarios) { index, scenario ->
-                val isSelected = selectedIndex == index
-                Text(
-                    scenario.name,
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .background(
-                            if (isSelected)
-                                MaterialTheme.colorScheme.primary.copy(alpha = 0.1f)
-                            else Color.Transparent
-                        )
-                        .clickable { selectedIndex = index }
-                        .padding(12.dp)
-                        .testTag("ScenarioItem$index")
-                )
+        Box(
+            modifier = Modifier
+                .weight(1f)
+                .fillMaxWidth()
+                .clip(RoundedCornerShape(8.dp))
+                .background(MaterialTheme.colorScheme.surfaceVariant)
+                .testTag("ScenarioList")
+        ) {
+            LazyColumn(modifier = Modifier.fillMaxSize()) {
+                itemsIndexed(scenarios) { index, scenario ->
+                    val isSelected = selectedIndex == index
+                    Text(
+                        scenario.name,
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .background(
+                                if (isSelected)
+                                    MaterialTheme.colorScheme.primary.copy(alpha = 0.1f)
+                                else Color.Transparent
+                            )
+                            .clickable { selectedIndex = index }
+                            .padding(12.dp)
+                            .testTag("ScenarioItem$index")
+                    )
+                }
             }
         }
         Spacer(modifier = Modifier.height(8.dp))

--- a/app/src/main/java/com/lnkv/nfcemulator/MainActivity.kt
+++ b/app/src/main/java/com/lnkv/nfcemulator/MainActivity.kt
@@ -158,10 +158,8 @@ fun CommunicationScreen(
         ) {
             Checkbox(
                 checked = showServer,
-                onCheckedChange = { checked ->
-                    if (!checked && !showNfc) return@Checkbox
-                    showServer = checked
-                },
+                onCheckedChange = { showServer = it },
+                enabled = showNfc || !showServer,
                 modifier = Modifier
                     .offset(x = (-4).dp)
                     .testTag("ServerCheck")
@@ -178,10 +176,8 @@ fun CommunicationScreen(
         ) {
             Checkbox(
                 checked = showNfc,
-                onCheckedChange = { checked ->
-                    if (!checked && !showServer) return@Checkbox
-                    showNfc = checked
-                },
+                onCheckedChange = { showNfc = it },
+                enabled = showServer || !showNfc,
                 modifier = Modifier
                     .offset(x = (-4).dp)
                     .testTag("NfcCheck")
@@ -202,38 +198,24 @@ fun CommunicationScreen(
         val serverEntries = entries.filter { it.isRequest }
         val nfcEntries = entries.filter { !it.isRequest }
 
-        when {
-            showServer && showNfc -> {
-                CommunicationLogList(
-                    label = "Server Communication",
-                    entries = serverEntries,
-                    tag = "ServerLog",
-                    modifier = Modifier.weight(1f)
-                )
-                Spacer(modifier = Modifier.height(8.dp))
-                CommunicationLogList(
-                    label = "NFC Communication",
-                    entries = nfcEntries,
-                    tag = "NfcLog",
-                    modifier = Modifier.weight(1f)
-                )
-            }
-            showServer -> {
-                CommunicationLogList(
-                    label = "Server Communication",
-                    entries = serverEntries,
-                    tag = "ServerLog",
-                    modifier = Modifier.weight(1f)
-                )
-            }
-            showNfc -> {
-                CommunicationLogList(
-                    label = "NFC Communication",
-                    entries = nfcEntries,
-                    tag = "NfcLog",
-                    modifier = Modifier.weight(1f)
-                )
-            }
+        if (showServer) {
+            CommunicationLogList(
+                label = "Server Communication",
+                entries = serverEntries,
+                tag = "ServerLog",
+                modifier = Modifier.weight(1f)
+            )
+        }
+        if (showServer && showNfc) {
+            Spacer(modifier = Modifier.height(8.dp))
+        }
+        if (showNfc) {
+            CommunicationLogList(
+                label = "NFC Communication",
+                entries = nfcEntries,
+                tag = "NfcLog",
+                modifier = Modifier.weight(1f)
+            )
         }
 
         Spacer(modifier = Modifier.height(8.dp))

--- a/app/src/main/java/com/lnkv/nfcemulator/MainActivity.kt
+++ b/app/src/main/java/com/lnkv/nfcemulator/MainActivity.kt
@@ -37,6 +37,9 @@ import androidx.compose.runtime.setValue
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.mutableStateListOf
+import androidx.compose.runtime.snapshots.SnapshotStateList
+import androidx.compose.runtime.saveable.Saver
+import androidx.compose.runtime.toMutableStateList
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.compose.foundation.layout.*
@@ -262,7 +265,11 @@ fun CommunicationScreen(
 
 @Composable
 fun ScenarioScreen(modifier: Modifier = Modifier) {
-    val scenarios = rememberSaveable {
+    val scenariosSaver = Saver<SnapshotStateList<Scenario>, List<String>>(
+        save = { list -> list.map { it.name } },
+        restore = { names -> names.map(::Scenario).toMutableStateList() }
+    )
+    val scenarios = rememberSaveable(saver = scenariosSaver) {
         mutableStateListOf(
             Scenario("Scenario 1"),
             Scenario("Scenario 2")

--- a/app/src/main/java/com/lnkv/nfcemulator/MainActivity.kt
+++ b/app/src/main/java/com/lnkv/nfcemulator/MainActivity.kt
@@ -34,8 +34,11 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.graphics.Color
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
-import androidx.compose.material3.Checkbox
-import androidx.compose.material3.CheckboxDefaults
+import androidx.compose.material.icons.filled.Check
+import androidx.compose.foundation.border
+import androidx.compose.foundation.selection.toggleable
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.ui.semantics.Role
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment.Companion.Center
 import androidx.compose.ui.platform.testTag
@@ -160,17 +163,10 @@ fun CommunicationScreen(
                 .padding(horizontal = 12.dp, vertical = 8.dp)
                 .testTag("ServerToggle")
         ) {
-            Checkbox(
+            CircleCheckbox(
                 checked = showServer,
                 onCheckedChange = { showServer = it },
                 enabled = showNfc || !showServer,
-                colors = CheckboxDefaults.colors(
-                    checkedColor = MaterialTheme.colorScheme.primary,
-                    uncheckedColor = MaterialTheme.colorScheme.outline,
-                    checkmarkColor = MaterialTheme.colorScheme.onPrimary,
-                    disabledCheckedColor = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.6f),
-                    disabledUncheckedColor = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.6f)
-                ),
                 modifier = Modifier.testTag("ServerCheck")
             )
             Spacer(modifier = Modifier.width(8.dp))
@@ -186,17 +182,10 @@ fun CommunicationScreen(
                 .padding(horizontal = 12.dp, vertical = 8.dp)
                 .testTag("NfcToggle")
         ) {
-            Checkbox(
+            CircleCheckbox(
                 checked = showNfc,
                 onCheckedChange = { showNfc = it },
                 enabled = showServer || !showNfc,
-                colors = CheckboxDefaults.colors(
-                    checkedColor = MaterialTheme.colorScheme.primary,
-                    uncheckedColor = MaterialTheme.colorScheme.outline,
-                    checkmarkColor = MaterialTheme.colorScheme.onPrimary,
-                    disabledCheckedColor = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.6f),
-                    disabledUncheckedColor = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.6f)
-                ),
                 modifier = Modifier.testTag("NfcCheck")
             )
             Spacer(modifier = Modifier.width(8.dp))
@@ -291,6 +280,49 @@ private fun CommunicationLogList(
                     Text(entry.message, color = color)
                 }
             }
+        }
+    }
+}
+
+@Composable
+private fun CircleCheckbox(
+    checked: Boolean,
+    onCheckedChange: (Boolean) -> Unit,
+    enabled: Boolean,
+    modifier: Modifier = Modifier
+) {
+    val scheme = MaterialTheme.colorScheme
+    val background = when {
+        !enabled -> scheme.surfaceVariant.copy(alpha = 0.6f)
+        checked -> scheme.primary
+        else -> Color.Transparent
+    }
+    val borderColor = when {
+        !enabled -> scheme.surfaceVariant.copy(alpha = 0.6f)
+        checked -> scheme.primary
+        else -> scheme.outline
+    }
+    Box(
+        modifier
+            .size(20.dp)
+            .clip(CircleShape)
+            .background(background)
+            .border(2.dp, borderColor, CircleShape)
+            .toggleable(
+                value = checked,
+                onValueChange = onCheckedChange,
+                enabled = enabled,
+                role = Role.Checkbox
+            ),
+        contentAlignment = Alignment.Center
+    ) {
+        if (checked) {
+            Icon(
+                imageVector = Icons.Filled.Check,
+                contentDescription = null,
+                tint = scheme.onPrimary,
+                modifier = Modifier.size(12.dp)
+            )
         }
     }
 }

--- a/app/src/main/java/com/lnkv/nfcemulator/MainActivity.kt
+++ b/app/src/main/java/com/lnkv/nfcemulator/MainActivity.kt
@@ -97,7 +97,7 @@ class MainActivity : ComponentActivity() {
  * Navigation targets displayed in the bottom bar.
  */
 enum class Screen(val label: String) {
-    Communication("Communication"),
+    Communication("Comm"),
     Scenario("Scenario"),
     Server("Server"),
     Settings("Settings")

--- a/app/src/main/java/com/lnkv/nfcemulator/MainActivity.kt
+++ b/app/src/main/java/com/lnkv/nfcemulator/MainActivity.kt
@@ -17,7 +17,7 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Button
 import androidx.compose.material3.OutlinedTextField
-import androidx.compose.ui.text.input.KeyboardOptions
+import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.ui.text.input.KeyboardType
 import android.widget.Toast
 import androidx.compose.material.icons.Icons

--- a/app/src/main/java/com/lnkv/nfcemulator/MainActivity.kt
+++ b/app/src/main/java/com/lnkv/nfcemulator/MainActivity.kt
@@ -408,6 +408,7 @@ fun ServerScreen(modifier: Modifier = Modifier) {
                 keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Ascii),
                 singleLine = true,
                 shape = RoundedCornerShape(12.dp),
+                enabled = !isServerConnected,
                 trailingIcon = {
                     IconButton(onClick = { ip = "" }, modifier = Modifier.testTag("IpClear")) {
                         Icon(Icons.Filled.Delete, contentDescription = "Clear IP")
@@ -443,6 +444,7 @@ fun ServerScreen(modifier: Modifier = Modifier) {
                 isError = pollingTime.isNotEmpty() && pollingTime.toInt() < 10,
                 shape = RoundedCornerShape(12.dp),
                 modifier = Modifier.fillMaxWidth().testTag("PollingField"),
+                enabled = !isServerConnected,
                 trailingIcon = {
                     IconButton(onClick = { pollingTime = "" }, modifier = Modifier.testTag("PollingClear")) {
                         Icon(Icons.Filled.Delete, contentDescription = "Clear Polling Time")
@@ -454,7 +456,8 @@ fun ServerScreen(modifier: Modifier = Modifier) {
                 CircleCheckbox(
                     checked = autoConnect,
                     onCheckedChange = { autoConnect = it },
-                    modifier = Modifier.testTag("AutoConnectCheck")
+                    modifier = Modifier.testTag("AutoConnectCheck"),
+                    enabled = !isServerConnected
                 )
                 Spacer(modifier = Modifier.width(8.dp))
                 Text("Connect Automatically")
@@ -478,6 +481,7 @@ fun ServerScreen(modifier: Modifier = Modifier) {
                     onClick = {
                         Toast.makeText(context, "Saved", Toast.LENGTH_SHORT).show()
                     },
+                    enabled = !isServerConnected,
                     modifier = Modifier.weight(1f).testTag("SaveServer")
                 ) {
                     Text("Save")
@@ -524,7 +528,8 @@ fun ServerScreen(modifier: Modifier = Modifier) {
                 CircleCheckbox(
                     checked = staticPort,
                     onCheckedChange = { staticPort = it },
-                    modifier = Modifier.testTag("StaticPortCheck")
+                    modifier = Modifier.testTag("StaticPortCheck"),
+                    enabled = !isServerRunning
                 )
                 Spacer(modifier = Modifier.width(8.dp))
                 Text("Use static port")
@@ -546,7 +551,7 @@ fun ServerScreen(modifier: Modifier = Modifier) {
                 label = { Text("Port") },
                 keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
                 singleLine = true,
-                enabled = staticPort,
+                enabled = staticPort && !isServerRunning,
                 shape = RoundedCornerShape(12.dp),
                 modifier = Modifier.fillMaxWidth().testTag("PortField"),
                 trailingIcon = {
@@ -560,7 +565,8 @@ fun ServerScreen(modifier: Modifier = Modifier) {
                 CircleCheckbox(
                     checked = autoStart,
                     onCheckedChange = { autoStart = it },
-                    modifier = Modifier.testTag("AutoStartCheck")
+                    modifier = Modifier.testTag("AutoStartCheck"),
+                    enabled = !isServerRunning
                 )
                 Spacer(modifier = Modifier.width(8.dp))
                 Text("Start Automatically")
@@ -584,6 +590,7 @@ fun ServerScreen(modifier: Modifier = Modifier) {
                     onClick = {
                         Toast.makeText(context, "Saved", Toast.LENGTH_SHORT).show()
                     },
+                    enabled = !isServerRunning,
                     modifier = Modifier.weight(1f).testTag("SaveServer")
                 ) {
                     Text("Save")
@@ -609,14 +616,14 @@ fun ServerScreen(modifier: Modifier = Modifier) {
             Box(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .heightIn(max = 100.dp)
+                    .height(150.dp)
                     .clip(RoundedCornerShape(8.dp))
                     .background(MaterialTheme.colorScheme.surfaceVariant)
                     .testTag("ConnectedList")
                     .padding(8.dp)
             ) {
                 if (connectedDevices.isNotEmpty()) {
-                    LazyColumn {
+                    LazyColumn(modifier = Modifier.fillMaxSize()) {
                         items(connectedDevices) { device ->
                             Text(device)
                         }

--- a/app/src/main/java/com/lnkv/nfcemulator/MainActivity.kt
+++ b/app/src/main/java/com/lnkv/nfcemulator/MainActivity.kt
@@ -41,7 +41,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.border
-import androidx.compose.foundation.toggleable
+import androidx.compose.foundation.selection.toggleable
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.icons.filled.Check
 import androidx.compose.material.icons.filled.Send

--- a/app/src/main/java/com/lnkv/nfcemulator/MainActivity.kt
+++ b/app/src/main/java/com/lnkv/nfcemulator/MainActivity.kt
@@ -61,6 +61,7 @@ import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.withStyle
 import java.io.File
 import com.lnkv.nfcemulator.cardservice.TypeAEmulatorService
 import com.lnkv.nfcemulator.ui.theme.NFCEmulatorTheme

--- a/app/src/main/java/com/lnkv/nfcemulator/MainActivity.kt
+++ b/app/src/main/java/com/lnkv/nfcemulator/MainActivity.kt
@@ -17,6 +17,7 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Button
 import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.IconButton
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.ui.text.input.KeyboardType
 import android.widget.Toast
@@ -37,6 +38,8 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.filled.Check
+import androidx.compose.material.icons.filled.Send
+import androidx.compose.material.icons.filled.Delete
 import androidx.compose.foundation.border
 import androidx.compose.foundation.selection.toggleable
 import androidx.compose.foundation.shape.CircleShape
@@ -228,18 +231,43 @@ fun CommunicationScreen(
         ) {
             OutlinedTextField(
                 value = command,
-                onValueChange = { if (it.matches(Regex("[0-9a-fA-F]*"))) command = it },
-                modifier = Modifier.weight(1f),
+                onValueChange = { value ->
+                    if (value.matches(Regex("[0-9a-fA-F]*"))) {
+                        command = value
+                    } else {
+                        Toast.makeText(
+                            context,
+                            "Command can contain only hex notation characters",
+                            Toast.LENGTH_SHORT
+                        ).show()
+                    }
+                },
+                modifier = Modifier.weight(1f).testTag("CommandField"),
                 label = { Text("Command") },
-                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Ascii)
+                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Ascii),
+                singleLine = true,
+                shape = RoundedCornerShape(12.dp)
             )
             Spacer(modifier = Modifier.width(8.dp))
-            Button(onClick = {
-                if (command.length % 2 != 0) {
-                    Toast.makeText(context, "Even amount of nibbles is required", Toast.LENGTH_SHORT).show()
-                }
-            }) {
-                Text("Send Command")
+            IconButton(
+                onClick = {
+                    if (command.length % 2 != 0) {
+                        Toast.makeText(
+                            context,
+                            "Even amount of nibbles is required",
+                            Toast.LENGTH_SHORT
+                        ).show()
+                    }
+                },
+                modifier = Modifier.testTag("CommandSend")
+            ) {
+                Icon(Icons.Filled.Send, contentDescription = "Send Command")
+            }
+            IconButton(
+                onClick = { command = "" },
+                modifier = Modifier.testTag("CommandClear")
+            ) {
+                Icon(Icons.Filled.Delete, contentDescription = "Clear Command")
             }
         }
         Spacer(modifier = Modifier.height(8.dp))

--- a/app/src/test/java/com/lnkv/nfcemulator/CommunicationScreenTest.kt
+++ b/app/src/test/java/com/lnkv/nfcemulator/CommunicationScreenTest.kt
@@ -104,5 +104,16 @@ class CommunicationScreenTest {
         assertEquals(expected, saveWidth)
         assertEquals(expected, clearWidth)
     }
+
+    @Test
+    fun commandButtonsDisplayedAndClearWorks() {
+        composeTestRule.setContent { CommunicationScreen(emptyList()) }
+        composeTestRule.onNodeWithTag("CommandSend").assertExists()
+        composeTestRule.onNodeWithTag("CommandClear").assertExists()
+
+        composeTestRule.onNodeWithTag("CommandField").performTextInput("AB")
+        composeTestRule.onNodeWithTag("CommandClear").performClick()
+        composeTestRule.onNodeWithTag("CommandField").assertTextEquals("")
+    }
 }
 

--- a/app/src/test/java/com/lnkv/nfcemulator/CommunicationScreenTest.kt
+++ b/app/src/test/java/com/lnkv/nfcemulator/CommunicationScreenTest.kt
@@ -40,25 +40,11 @@ class CommunicationScreenTest {
         }
 
         val heightBoth = composeTestRule.onNodeWithTag("ServerLog").fetchSemanticsNode().size.height
-        composeTestRule.onNodeWithText("NFC Communication").performClick()
+        composeTestRule.onNodeWithTag("NfcToggle").performClick()
         composeTestRule.waitForIdle()
         val heightSingle = composeTestRule.onNodeWithTag("ServerLog").fetchSemanticsNode().size.height
         assertTrue(heightSingle > heightBoth)
         composeTestRule.onNodeWithText("A1B2").assertDoesNotExist()
-    }
-
-    @Test
-    fun toggleRowsFillWidth() {
-        composeTestRule.setContent { CommunicationScreen(emptyList()) }
-
-        val rootWidth = composeTestRule.onRoot().fetchSemanticsNode().size.width
-        val expectedWidth = rootWidth - with(composeTestRule.density) { 32.dp.roundToPx() }
-
-        val serverWidth = composeTestRule.onNodeWithTag("ServerToggle").fetchSemanticsNode().size.width
-        val nfcWidth = composeTestRule.onNodeWithTag("NfcToggle").fetchSemanticsNode().size.width
-
-        assertEquals(expectedWidth, serverWidth)
-        assertEquals(expectedWidth, nfcWidth)
     }
 
     @Test
@@ -69,19 +55,6 @@ class CommunicationScreenTest {
         val dividerWidth = composeTestRule.onNodeWithTag("ToggleDivider").fetchSemanticsNode().size.width
 
         assertEquals(logWidth, dividerWidth)
-    }
-
-    @Test
-    fun togglesAlignWithLogs() {
-        composeTestRule.setContent { CommunicationScreen(emptyList()) }
-        val serverToggleX = composeTestRule.onNodeWithTag("ServerToggle").fetchSemanticsNode().positionInRoot.x
-        val serverLogX = composeTestRule.onNodeWithTag("ServerLog").fetchSemanticsNode().positionInRoot.x
-
-        val nfcToggleX = composeTestRule.onNodeWithTag("NfcToggle").fetchSemanticsNode().positionInRoot.x
-        val nfcLogX = composeTestRule.onNodeWithTag("NfcLog").fetchSemanticsNode().positionInRoot.x
-
-        assertEquals(serverLogX, serverToggleX)
-        assertEquals(nfcLogX, nfcToggleX)
     }
 
     @Test
@@ -105,5 +78,22 @@ class CommunicationScreenTest {
         assertEquals(expected, clearWidth)
     }
 
+    @Test
+    fun segmentsFillWidth() {
+        composeTestRule.setContent { CommunicationScreen(emptyList()) }
+
+        val rootWidth = composeTestRule.onRoot().fetchSemanticsNode().size.width
+        val expectedWidth = rootWidth - with(composeTestRule.density) { 32.dp.roundToPx() }
+        val segWidth = composeTestRule.onNodeWithTag("CommSegments").fetchSemanticsNode().size.width
+
+        assertEquals(expectedWidth, segWidth)
+    }
+
+    @Test
+    fun lastSegmentDisables() {
+        composeTestRule.setContent { CommunicationScreen(emptyList()) }
+        composeTestRule.onNodeWithTag("NfcToggle").performClick()
+        composeTestRule.onNodeWithTag("ServerToggle").assertIsNotEnabled()
+    }
 }
 

--- a/app/src/test/java/com/lnkv/nfcemulator/CommunicationScreenTest.kt
+++ b/app/src/test/java/com/lnkv/nfcemulator/CommunicationScreenTest.kt
@@ -105,15 +105,5 @@ class CommunicationScreenTest {
         assertEquals(expected, clearWidth)
     }
 
-    @Test
-    fun commandButtonsDisplayedAndClearWorks() {
-        composeTestRule.setContent { CommunicationScreen(emptyList()) }
-        composeTestRule.onNodeWithTag("CommandSend").assertExists()
-        composeTestRule.onNodeWithTag("CommandClear").assertExists()
-
-        composeTestRule.onNodeWithTag("CommandField").performTextInput("AB")
-        composeTestRule.onNodeWithTag("CommandClear").performClick()
-        composeTestRule.onNodeWithTag("CommandField").assertTextEquals("")
-    }
 }
 

--- a/app/src/test/java/com/lnkv/nfcemulator/CommunicationScreenTest.kt
+++ b/app/src/test/java/com/lnkv/nfcemulator/CommunicationScreenTest.kt
@@ -85,19 +85,24 @@ class CommunicationScreenTest {
     }
 
     @Test
-    fun saveButtonIsDisplayed() {
+    fun actionButtonsDisplayed() {
         composeTestRule.setContent { CommunicationScreen(emptyList()) }
         composeTestRule.onNodeWithTag("SaveButton").assertExists()
+        composeTestRule.onNodeWithTag("ClearButton").assertExists()
     }
 
     @Test
-    fun saveButtonMatchesLogWidth() {
+    fun actionButtonsMatchLogWidth() {
         composeTestRule.setContent { CommunicationScreen(emptyList()) }
 
         val logWidth = composeTestRule.onNodeWithTag("ServerLog").fetchSemanticsNode().size.width
-        val buttonWidth = composeTestRule.onNodeWithTag("SaveButton").fetchSemanticsNode().size.width
+        val spacing = with(composeTestRule.density) { 8.dp.roundToPx() }
+        val expected = (logWidth - spacing) / 2
+        val saveWidth = composeTestRule.onNodeWithTag("SaveButton").fetchSemanticsNode().size.width
+        val clearWidth = composeTestRule.onNodeWithTag("ClearButton").fetchSemanticsNode().size.width
 
-        assertEquals(logWidth, buttonWidth)
+        assertEquals(expected, saveWidth)
+        assertEquals(expected, clearWidth)
     }
 }
 

--- a/app/src/test/java/com/lnkv/nfcemulator/MainScreenTest.kt
+++ b/app/src/test/java/com/lnkv/nfcemulator/MainScreenTest.kt
@@ -13,6 +13,7 @@ class MainScreenTest {
     fun navigationIconsPresent() {
         composeTestRule.setContent { MainScreen() }
         composeTestRule.onNodeWithContentDescription("Communication").assertExists()
+        composeTestRule.onNodeWithContentDescription("Scenario").assertExists()
         composeTestRule.onNodeWithContentDescription("Server").assertExists()
         composeTestRule.onNodeWithContentDescription("Settings").assertExists()
     }

--- a/app/src/test/java/com/lnkv/nfcemulator/MainScreenTest.kt
+++ b/app/src/test/java/com/lnkv/nfcemulator/MainScreenTest.kt
@@ -12,7 +12,7 @@ class MainScreenTest {
     @Test
     fun navigationIconsPresent() {
         composeTestRule.setContent { MainScreen() }
-        composeTestRule.onNodeWithContentDescription("Communication").assertExists()
+        composeTestRule.onNodeWithContentDescription("Comm").assertExists()
         composeTestRule.onNodeWithContentDescription("Scenario").assertExists()
         composeTestRule.onNodeWithContentDescription("Server").assertExists()
         composeTestRule.onNodeWithContentDescription("Settings").assertExists()

--- a/app/src/test/java/com/lnkv/nfcemulator/MainScreenTest.kt
+++ b/app/src/test/java/com/lnkv/nfcemulator/MainScreenTest.kt
@@ -1,52 +1,13 @@
 package com.lnkv.nfcemulator
 
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.toArgb
-import androidx.compose.ui.graphics.toPixelMap
-import androidx.compose.ui.test.captureToImage
 import androidx.compose.ui.test.junit4.createComposeRule
-import androidx.compose.ui.test.onNodeWithTag
-import androidx.compose.ui.test.onNodeWithText
-import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.onNodeWithContentDescription
-import androidx.compose.material3.MaterialTheme
 import org.junit.Rule
 import org.junit.Test
-import kotlin.test.assertEquals
-import com.lnkv.nfcemulator.ui.theme.NFCEmulatorTheme
 
 class MainScreenTest {
     @get:Rule
     val composeTestRule = createComposeRule()
-
-    @Test
-    fun headerUpdatesWithNavigation() {
-        composeTestRule.setContent { MainScreen() }
-
-        composeTestRule.onNodeWithTag("ScreenHeader").assertExists()
-        composeTestRule.onNodeWithTag("ScreenHeader").assertTextEquals("COMMUNICATION")
-
-        composeTestRule.onNodeWithText("Server").performClick()
-        composeTestRule.onNodeWithTag("ScreenHeader").assertTextEquals("SERVER")
-
-        composeTestRule.onNodeWithText("Settings").performClick()
-        composeTestRule.onNodeWithTag("ScreenHeader").assertTextEquals("SETTINGS")
-    }
-
-    @Test
-    fun topBarUsesPrimaryColor() {
-        var expected = Color.Unspecified
-        composeTestRule.setContent {
-            NFCEmulatorTheme {
-                expected = MaterialTheme.colorScheme.primary
-                MainScreen()
-            }
-        }
-
-        val image = composeTestRule.onNodeWithTag("TopBar").captureToImage()
-        val actual = image.toPixelMap()[0, 0]
-        assertEquals(expected.toArgb(), actual.toArgb())
-    }
 
     @Test
     fun navigationIconsPresent() {

--- a/app/src/test/java/com/lnkv/nfcemulator/ScenarioScreenTest.kt
+++ b/app/src/test/java/com/lnkv/nfcemulator/ScenarioScreenTest.kt
@@ -1,10 +1,11 @@
 package com.lnkv.nfcemulator
 
+import androidx.compose.ui.test.assertIsEnabled
+import androidx.compose.ui.test.assertIsNotEnabled
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
-import androidx.compose.ui.test.performTextInput
+import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
-import androidx.compose.ui.test.assertTextEquals
 import org.junit.Rule
 import org.junit.Test
 
@@ -13,20 +14,17 @@ class ScenarioScreenTest {
     val composeTestRule = createComposeRule()
 
     @Test
-    fun commandButtonsDisplayedAndClearWorks() {
+    fun editButtonEnabledWhenScenarioSelected() {
         composeTestRule.setContent { ScenarioScreen() }
-        composeTestRule.onNodeWithTag("CommandSend").assertExists()
-        composeTestRule.onNodeWithTag("CommandClear").assertExists()
-
-        composeTestRule.onNodeWithTag("CommandField").performTextInput("AB")
-        composeTestRule.onNodeWithTag("CommandClear").performClick()
-        composeTestRule.onNodeWithTag("CommandField").assertTextEquals("")
+        composeTestRule.onNodeWithTag("ScenarioEdit").assertIsNotEnabled()
+        composeTestRule.onNodeWithTag("ScenarioItem0").performClick()
+        composeTestRule.onNodeWithTag("ScenarioEdit").assertIsEnabled()
     }
 
     @Test
-    fun titleRejectsInvalidCharacters() {
+    fun newButtonAddsScenario() {
         composeTestRule.setContent { ScenarioScreen() }
-        composeTestRule.onNodeWithTag("TitleField").performTextInput("test/")
-        composeTestRule.onNodeWithTag("TitleField").assertTextEquals("test")
+        composeTestRule.onNodeWithTag("ScenarioNew").performClick()
+        composeTestRule.onNodeWithText("Scenario 3").assertExists()
     }
 }

--- a/app/src/test/java/com/lnkv/nfcemulator/ScenarioScreenTest.kt
+++ b/app/src/test/java/com/lnkv/nfcemulator/ScenarioScreenTest.kt
@@ -1,0 +1,25 @@
+package com.lnkv.nfcemulator
+
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performTextInput
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.assertTextEquals
+import org.junit.Rule
+import org.junit.Test
+
+class ScenarioScreenTest {
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    @Test
+    fun commandButtonsDisplayedAndClearWorks() {
+        composeTestRule.setContent { ScenarioScreen() }
+        composeTestRule.onNodeWithTag("CommandSend").assertExists()
+        composeTestRule.onNodeWithTag("CommandClear").assertExists()
+
+        composeTestRule.onNodeWithTag("CommandField").performTextInput("AB")
+        composeTestRule.onNodeWithTag("CommandClear").performClick()
+        composeTestRule.onNodeWithTag("CommandField").assertTextEquals("")
+    }
+}

--- a/app/src/test/java/com/lnkv/nfcemulator/ScenarioScreenTest.kt
+++ b/app/src/test/java/com/lnkv/nfcemulator/ScenarioScreenTest.kt
@@ -27,4 +27,10 @@ class ScenarioScreenTest {
         composeTestRule.onNodeWithTag("ScenarioNew").performClick()
         composeTestRule.onNodeWithText("Scenario 3").assertExists()
     }
+
+    @Test
+    fun scenarioListHasBackgroundContainer() {
+        composeTestRule.setContent { ScenarioScreen() }
+        composeTestRule.onNodeWithTag("ScenarioList").assertExists()
+    }
 }

--- a/app/src/test/java/com/lnkv/nfcemulator/ScenarioScreenTest.kt
+++ b/app/src/test/java/com/lnkv/nfcemulator/ScenarioScreenTest.kt
@@ -22,4 +22,11 @@ class ScenarioScreenTest {
         composeTestRule.onNodeWithTag("CommandClear").performClick()
         composeTestRule.onNodeWithTag("CommandField").assertTextEquals("")
     }
+
+    @Test
+    fun titleRejectsInvalidCharacters() {
+        composeTestRule.setContent { ScenarioScreen() }
+        composeTestRule.onNodeWithTag("TitleField").performTextInput("test/")
+        composeTestRule.onNodeWithTag("TitleField").assertTextEquals("test")
+    }
 }

--- a/app/src/test/java/com/lnkv/nfcemulator/ServerScreenTest.kt
+++ b/app/src/test/java/com/lnkv/nfcemulator/ServerScreenTest.kt
@@ -1,7 +1,5 @@
 package com.lnkv.nfcemulator
 
-import androidx.compose.ui.test.assertIsEnabled
-import androidx.compose.ui.test.assertIsNotEnabled
 import androidx.compose.ui.test.assertIsSelected
 import androidx.compose.ui.test.assertIsNotSelected
 import androidx.compose.ui.test.assertIsOn
@@ -11,6 +9,7 @@ import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performTextInput
 import androidx.compose.ui.test.performTextClearance
 import androidx.compose.ui.test.assertTextEquals
+import androidx.compose.ui.test.performClick
 import org.junit.Rule
 import org.junit.Test
 
@@ -19,29 +18,23 @@ class ServerScreenTest {
     val composeTestRule = createComposeRule()
 
     @Test
-    fun ipButtonsDisplayedAndClearWorks() {
+    fun ipClearWorks() {
         composeTestRule.setContent { ServerScreen() }
-        composeTestRule.onNodeWithTag("IpApply").assertExists()
-        composeTestRule.onNodeWithTag("IpClear").assertExists()
-
-        composeTestRule.onNodeWithTag("IpField").performTextInput("192.168.0.1")
         composeTestRule.onNodeWithTag("IpClear").performClick()
         composeTestRule.onNodeWithTag("IpField").assertTextEquals("")
     }
 
     @Test
-    fun applyDisabledForInvalidIp() {
+    fun pollingClearWorks() {
         composeTestRule.setContent { ServerScreen() }
-        composeTestRule.onNodeWithTag("IpField").performTextInput("999.999.1.1")
-        composeTestRule.onNodeWithTag("IpApply").assertIsNotEnabled()
-        composeTestRule.onNodeWithTag("IpField").performTextClearance()
-        composeTestRule.onNodeWithTag("IpField").performTextInput("192.168.0.1")
-        composeTestRule.onNodeWithTag("IpApply").assertIsEnabled()
+        composeTestRule.onNodeWithTag("PollingClear").performClick()
+        composeTestRule.onNodeWithTag("PollingField").assertTextEquals("")
     }
 
     @Test
     fun disallowsLetters() {
         composeTestRule.setContent { ServerScreen() }
+        composeTestRule.onNodeWithTag("IpClear").performClick()
         composeTestRule.onNodeWithTag("IpField").performTextInput("192a")
         composeTestRule.onNodeWithTag("IpField").assertTextEquals("192")
     }
@@ -62,6 +55,7 @@ class ServerScreenTest {
     fun pollingFieldRestrictsInput() {
         composeTestRule.setContent { ServerScreen() }
         val field = composeTestRule.onNodeWithTag("PollingField")
+        field.performTextClearance()
         field.performTextInput("123a")
         field.assertTextEquals("123")
         field.performTextClearance()
@@ -76,5 +70,24 @@ class ServerScreenTest {
         check.assertIsOff()
         check.performClick()
         check.assertIsOn()
+    }
+
+    @Test
+    fun connectButtonTogglesState() {
+        composeTestRule.setContent { ServerScreen() }
+        composeTestRule.onNodeWithTag("ServerState").assertTextEquals("Server State: Disconnected")
+        composeTestRule.onNodeWithTag("ConnectButton").performClick()
+        composeTestRule.onNodeWithTag("ServerState").assertTextEquals("Server State: Connected")
+        composeTestRule.onNodeWithTag("ConnectButton").performClick()
+        composeTestRule.onNodeWithTag("ServerState").assertTextEquals("Server State: Disconnected")
+    }
+
+    @Test
+    fun connectRequiresInputs() {
+        composeTestRule.setContent { ServerScreen() }
+        composeTestRule.onNodeWithTag("IpClear").performClick()
+        composeTestRule.onNodeWithTag("PollingClear").performClick()
+        composeTestRule.onNodeWithTag("ConnectButton").performClick()
+        composeTestRule.onNodeWithTag("ServerState").assertTextEquals("Server State: Disconnected")
     }
 }

--- a/app/src/test/java/com/lnkv/nfcemulator/ServerScreenTest.kt
+++ b/app/src/test/java/com/lnkv/nfcemulator/ServerScreenTest.kt
@@ -2,6 +2,8 @@ package com.lnkv.nfcemulator
 
 import androidx.compose.ui.test.assertIsEnabled
 import androidx.compose.ui.test.assertIsNotEnabled
+import androidx.compose.ui.test.assertIsSelected
+import androidx.compose.ui.test.assertIsNotSelected
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performTextInput
@@ -40,5 +42,17 @@ class ServerScreenTest {
         composeTestRule.setContent { ServerScreen() }
         composeTestRule.onNodeWithTag("IpField").performTextInput("192a")
         composeTestRule.onNodeWithTag("IpField").assertTextEquals("192")
+    }
+
+    @Test
+    fun serverTypeSegmentedButtonsWork() {
+        composeTestRule.setContent { ServerScreen() }
+        val external = composeTestRule.onNodeWithTag("ExternalToggle")
+        val internal = composeTestRule.onNodeWithTag("InternalToggle")
+        external.assertIsSelected()
+        internal.assertIsNotSelected()
+        internal.performClick()
+        internal.assertIsSelected()
+        external.assertIsNotSelected()
     }
 }

--- a/app/src/test/java/com/lnkv/nfcemulator/ServerScreenTest.kt
+++ b/app/src/test/java/com/lnkv/nfcemulator/ServerScreenTest.kt
@@ -4,6 +4,8 @@ import androidx.compose.ui.test.assertIsSelected
 import androidx.compose.ui.test.assertIsNotSelected
 import androidx.compose.ui.test.assertIsOn
 import androidx.compose.ui.test.assertIsOff
+import androidx.compose.ui.test.assertIsEnabled
+import androidx.compose.ui.test.assertIsNotEnabled
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performTextInput
@@ -89,5 +91,26 @@ class ServerScreenTest {
         composeTestRule.onNodeWithTag("PollingClear").performClick()
         composeTestRule.onNodeWithTag("ConnectButton").performClick()
         composeTestRule.onNodeWithTag("ServerState").assertTextEquals("Server State: Disconnected")
+    }
+
+    @Test
+    fun staticPortCheckboxEnablesField() {
+        composeTestRule.setContent { ServerScreen() }
+        composeTestRule.onNodeWithTag("InternalToggle").performClick()
+        val portField = composeTestRule.onNodeWithTag("PortField")
+        portField.assertIsNotEnabled()
+        composeTestRule.onNodeWithTag("StaticPortCheck").performClick()
+        portField.assertIsEnabled()
+    }
+
+    @Test
+    fun startButtonTogglesState() {
+        composeTestRule.setContent { ServerScreen() }
+        composeTestRule.onNodeWithTag("InternalToggle").performClick()
+        composeTestRule.onNodeWithTag("ServerState").assertTextEquals("Server State: Stopped")
+        composeTestRule.onNodeWithTag("StartButton").performClick()
+        composeTestRule.onNodeWithTag("ServerState").assertTextEquals("Server State: Running")
+        composeTestRule.onNodeWithTag("StartButton").performClick()
+        composeTestRule.onNodeWithTag("ServerState").assertTextEquals("Server State: Stopped")
     }
 }

--- a/app/src/test/java/com/lnkv/nfcemulator/ServerScreenTest.kt
+++ b/app/src/test/java/com/lnkv/nfcemulator/ServerScreenTest.kt
@@ -34,11 +34,11 @@ class ServerScreenTest {
     }
 
     @Test
-    fun disallowsLetters() {
+    fun disallowsInvalidCharacters() {
         composeTestRule.setContent { ServerScreen() }
         composeTestRule.onNodeWithTag("IpClear").performClick()
-        composeTestRule.onNodeWithTag("IpField").performTextInput("192a")
-        composeTestRule.onNodeWithTag("IpField").assertTextEquals("192")
+        composeTestRule.onNodeWithTag("IpField").performTextInput("192.168.0.1:a")
+        composeTestRule.onNodeWithTag("IpField").assertTextEquals("192.168.0.1:")
     }
 
     @Test
@@ -89,6 +89,16 @@ class ServerScreenTest {
         composeTestRule.setContent { ServerScreen() }
         composeTestRule.onNodeWithTag("IpClear").performClick()
         composeTestRule.onNodeWithTag("PollingClear").performClick()
+        composeTestRule.onNodeWithTag("ConnectButton").performClick()
+        composeTestRule.onNodeWithTag("ServerState").assertTextEquals("Server State: Disconnected")
+    }
+
+    @Test
+    fun connectRequiresPort() {
+        composeTestRule.setContent { ServerScreen() }
+        val field = composeTestRule.onNodeWithTag("IpField")
+        field.performTextClearance()
+        field.performTextInput("192.168.0.1")
         composeTestRule.onNodeWithTag("ConnectButton").performClick()
         composeTestRule.onNodeWithTag("ServerState").assertTextEquals("Server State: Disconnected")
     }

--- a/app/src/test/java/com/lnkv/nfcemulator/ServerScreenTest.kt
+++ b/app/src/test/java/com/lnkv/nfcemulator/ServerScreenTest.kt
@@ -85,6 +85,16 @@ class ServerScreenTest {
     }
 
     @Test
+    fun externalFieldsDisabledWhenConnected() {
+        composeTestRule.setContent { ServerScreen() }
+        composeTestRule.onNodeWithTag("ConnectButton").performClick()
+        composeTestRule.onNodeWithTag("IpField").assertIsNotEnabled()
+        composeTestRule.onNodeWithTag("PollingField").assertIsNotEnabled()
+        composeTestRule.onNodeWithTag("AutoConnectCheck").assertIsNotEnabled()
+        composeTestRule.onNodeWithTag("SaveServer").assertIsNotEnabled()
+    }
+
+    @Test
     fun connectRequiresInputs() {
         composeTestRule.setContent { ServerScreen() }
         composeTestRule.onNodeWithTag("IpClear").performClick()
@@ -122,5 +132,16 @@ class ServerScreenTest {
         composeTestRule.onNodeWithTag("ServerState").assertTextEquals("Server State: Running")
         composeTestRule.onNodeWithTag("StartButton").performClick()
         composeTestRule.onNodeWithTag("ServerState").assertTextEquals("Server State: Stopped")
+    }
+
+    @Test
+    fun internalControlsDisabledWhenRunning() {
+        composeTestRule.setContent { ServerScreen() }
+        composeTestRule.onNodeWithTag("InternalToggle").performClick()
+        composeTestRule.onNodeWithTag("StartButton").performClick()
+        composeTestRule.onNodeWithTag("StaticPortCheck").assertIsNotEnabled()
+        composeTestRule.onNodeWithTag("AutoStartCheck").assertIsNotEnabled()
+        composeTestRule.onNodeWithTag("PortField").assertIsNotEnabled()
+        composeTestRule.onNodeWithTag("SaveServer").assertIsNotEnabled()
     }
 }

--- a/app/src/test/java/com/lnkv/nfcemulator/ServerScreenTest.kt
+++ b/app/src/test/java/com/lnkv/nfcemulator/ServerScreenTest.kt
@@ -4,6 +4,8 @@ import androidx.compose.ui.test.assertIsEnabled
 import androidx.compose.ui.test.assertIsNotEnabled
 import androidx.compose.ui.test.assertIsSelected
 import androidx.compose.ui.test.assertIsNotSelected
+import androidx.compose.ui.test.assertIsOn
+import androidx.compose.ui.test.assertIsOff
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performTextInput
@@ -54,5 +56,25 @@ class ServerScreenTest {
         internal.performClick()
         internal.assertIsSelected()
         external.assertIsNotSelected()
+    }
+
+    @Test
+    fun pollingFieldRestrictsInput() {
+        composeTestRule.setContent { ServerScreen() }
+        val field = composeTestRule.onNodeWithTag("PollingField")
+        field.performTextInput("123a")
+        field.assertTextEquals("123")
+        field.performTextClearance()
+        field.performTextInput("10001")
+        field.assertTextEquals("1000")
+    }
+
+    @Test
+    fun autoConnectCheckboxToggles() {
+        composeTestRule.setContent { ServerScreen() }
+        val check = composeTestRule.onNodeWithTag("AutoConnectCheck")
+        check.assertIsOff()
+        check.performClick()
+        check.assertIsOn()
     }
 }

--- a/app/src/test/java/com/lnkv/nfcemulator/ServerScreenTest.kt
+++ b/app/src/test/java/com/lnkv/nfcemulator/ServerScreenTest.kt
@@ -1,0 +1,44 @@
+package com.lnkv.nfcemulator
+
+import androidx.compose.ui.test.assertIsEnabled
+import androidx.compose.ui.test.assertIsNotEnabled
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performTextInput
+import androidx.compose.ui.test.performTextClearance
+import androidx.compose.ui.test.assertTextEquals
+import org.junit.Rule
+import org.junit.Test
+
+class ServerScreenTest {
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    @Test
+    fun ipButtonsDisplayedAndClearWorks() {
+        composeTestRule.setContent { ServerScreen() }
+        composeTestRule.onNodeWithTag("IpApply").assertExists()
+        composeTestRule.onNodeWithTag("IpClear").assertExists()
+
+        composeTestRule.onNodeWithTag("IpField").performTextInput("192.168.0.1")
+        composeTestRule.onNodeWithTag("IpClear").performClick()
+        composeTestRule.onNodeWithTag("IpField").assertTextEquals("")
+    }
+
+    @Test
+    fun applyDisabledForInvalidIp() {
+        composeTestRule.setContent { ServerScreen() }
+        composeTestRule.onNodeWithTag("IpField").performTextInput("999.999.1.1")
+        composeTestRule.onNodeWithTag("IpApply").assertIsNotEnabled()
+        composeTestRule.onNodeWithTag("IpField").performTextClearance()
+        composeTestRule.onNodeWithTag("IpField").performTextInput("192.168.0.1")
+        composeTestRule.onNodeWithTag("IpApply").assertIsEnabled()
+    }
+
+    @Test
+    fun disallowsLetters() {
+        composeTestRule.setContent { ServerScreen() }
+        composeTestRule.onNodeWithTag("IpField").performTextInput("192a")
+        composeTestRule.onNodeWithTag("IpField").assertTextEquals("192")
+    }
+}


### PR DESCRIPTION
## Summary
- Replaced the old scenario editor with a selectable list of Scenario items plus “New”, “Edit”, “Save”, and “Clear” controls, using a custom Saver to persist the list

- Introduced a dedicated Scenario tab in the bottom navigation; command field and send/clear buttons now live on the Scenario screen, with filename-safe “Title” validation

- Converted Communication screen checkboxes to a two-option segmented control; segments highlight brightly, disable when they are the only active option, and show logs accordingly

- Renamed the bottom navigation “Communication” tab to “Comm” to fit the label space

- Added external/internal selector at the top of the Server screen and split server configuration into “Save” and “Connect/Disconnect” buttons with a bold “Server State” display

- Added numeric “Polling Time [Ms]” (10–10000) with default 100 ms, IP address/port inputs, auto-connect circular checkbox, and validation alerts for invalid fields

- Enhanced external-server handling with IP:port filtering, offline IP detection, scrollable device list styled like Communication text boxes, and disabled fields while connected

- Enabled internal-server management: static port, auto-start checkbox, Start/Close button, and a list of connected devices; relevant fields lock when server runs

- Added segment and checkbox styling, rounded surfaces, and improved visibility for disabled circular checkboxes across the app

- Created tests covering new navigation, segmented controls, scenario list persistence, command send/clear behavior, server IP validation, and server-state toggling

Testing

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68a10870c4748330bfe1f6c9f39b3ee7