### PR TITLE
Persist scenario/server data and improve connection handling

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -54,6 +54,7 @@ dependencies {
     testImplementation(libs.junit)
     testImplementation(platform(libs.androidx.compose.bom))
     testImplementation(libs.androidx.ui.test.junit4)
+    testImplementation(libs.androidx.test.core)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)
     androidTestImplementation(platform(libs.androidx.compose.bom))

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -19,6 +19,7 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/Theme.NFCEmulator"
+        android:usesCleartextTraffic="true"
         tools:targetApi="31">
         <activity
             android:name=".MainActivity"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -3,6 +3,8 @@
     xmlns:tools="http://schemas.android.com/tools">
 
     <uses-permission android:name="android.permission.NFC" />
+    <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
     <uses-feature
         android:name="android.hardware.nfc.hce"
         android:required="true" />

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -5,6 +5,7 @@
     <uses-permission android:name="android.permission.NFC" />
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-feature
         android:name="android.hardware.nfc.hce"
         android:required="true" />

--- a/app/src/main/java/com/lnkv/nfcemulator/CommunicationLog.kt
+++ b/app/src/main/java/com/lnkv/nfcemulator/CommunicationLog.kt
@@ -8,7 +8,11 @@ import java.io.File
  * Holds APDU communication logs between the external reader and the emulator.
  */
 object CommunicationLog {
-    data class Entry(val message: String, val isRequest: Boolean)
+    data class Entry(
+        val message: String,
+        val isServer: Boolean,
+        val isSuccess: Boolean? = null
+    )
 
     private val _entries = MutableStateFlow<List<Entry>>(emptyList())
     val entries = _entries.asStateFlow()
@@ -16,10 +20,11 @@ object CommunicationLog {
     /**
      * Appends a new log entry.
      * @param message Hex representation of APDU data.
-     * @param isRequest True if the message came from the external reader.
+     * @param isServer True if the message came from the server side.
+     * @param isSuccess Optional flag indicating success or failure for colored logs.
      */
-    fun add(message: String, isRequest: Boolean) {
-        _entries.value = _entries.value + Entry(message, isRequest)
+    fun add(message: String, isServer: Boolean, isSuccess: Boolean? = null) {
+        _entries.value = _entries.value + Entry(message, isServer, isSuccess)
     }
 
     /**

--- a/app/src/main/java/com/lnkv/nfcemulator/CommunicationLog.kt
+++ b/app/src/main/java/com/lnkv/nfcemulator/CommunicationLog.kt
@@ -11,7 +11,8 @@ object CommunicationLog {
     data class Entry(
         val message: String,
         val isServer: Boolean,
-        val isSuccess: Boolean? = null
+        val isSuccess: Boolean? = null,
+        val timestamp: Long = System.currentTimeMillis()
     )
 
     private val _entries = MutableStateFlow<List<Entry>>(emptyList())

--- a/app/src/main/java/com/lnkv/nfcemulator/MainActivity.kt
+++ b/app/src/main/java/com/lnkv/nfcemulator/MainActivity.kt
@@ -944,7 +944,7 @@ fun ServerScreen(modifier: Modifier = Modifier) {
     var ip by rememberSaveable { mutableStateOf(prefs.getString("ip", "0.0.0.0:0000")!!) }
     var pollingTime by rememberSaveable { mutableStateOf(prefs.getString("pollingTime", "")!!) }
     var autoConnect by rememberSaveable { mutableStateOf(prefs.getBoolean("autoConnect", false)) }
-    val serverState by ServerConnectionManager.state
+    val serverState = ServerConnectionManager.state
     val isProcessing = ServerConnectionManager.isProcessing
     var port by rememberSaveable { mutableStateOf(prefs.getString("port", "0000")!!) }
     var staticPort by rememberSaveable { mutableStateOf(prefs.getBoolean("staticPort", false)) }

--- a/app/src/main/java/com/lnkv/nfcemulator/MainActivity.kt
+++ b/app/src/main/java/com/lnkv/nfcemulator/MainActivity.kt
@@ -6,6 +6,8 @@ import android.content.ComponentName
 import android.content.Context
 import android.content.SharedPreferences
 import android.net.wifi.WifiManager
+import android.net.ConnectivityManager
+import android.net.NetworkCapabilities
 import android.nfc.NfcAdapter
 import android.nfc.cardemulation.CardEmulation
 import android.os.Bundle
@@ -1110,9 +1112,13 @@ fun ServerScreen(modifier: Modifier = Modifier) {
                                 ).show()
                             } else {
                                 try {
-                                    val wifiManager =
-                                        context.applicationContext.getSystemService(Context.WIFI_SERVICE) as WifiManager
-                                    if (wifiManager.connectionInfo.networkId == -1) {
+                                    val connectivityManager =
+                                        context.getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
+                                    val wifiConnected =
+                                        connectivityManager.getNetworkCapabilities(
+                                            connectivityManager.activeNetwork
+                                        )?.hasTransport(NetworkCapabilities.TRANSPORT_WIFI) == true
+                                    if (!wifiConnected) {
                                         Toast.makeText(
                                             context,
                                             "Not connected to Wi-Fi",

--- a/app/src/main/java/com/lnkv/nfcemulator/MainActivity.kt
+++ b/app/src/main/java/com/lnkv/nfcemulator/MainActivity.kt
@@ -1109,34 +1109,38 @@ fun ServerScreen(modifier: Modifier = Modifier) {
                                     Toast.LENGTH_SHORT
                                 ).show()
                             } else {
-                                val wifiManager =
-                                    context.applicationContext.getSystemService(Context.WIFI_SERVICE) as WifiManager
-                                if (wifiManager.connectionInfo.networkId == -1) {
-                                    Toast.makeText(
-                                        context,
-                                        "Not connected to Wi-Fi",
-                                        Toast.LENGTH_SHORT
-                                    ).show()
-                                    serverState = "Disconnected"
-                                } else {
-                                    scope.launch {
-                                        try {
-                                            val s = withContext(Dispatchers.IO) {
-                                                Socket().apply {
-                                                    connect(
-                                                        InetSocketAddress(ip.substringBefore(":"), portPart),
-                                                        5000
-                                                    )
+                                try {
+                                    val wifiManager =
+                                        context.applicationContext.getSystemService(Context.WIFI_SERVICE) as WifiManager
+                                    if (wifiManager.connectionInfo.networkId == -1) {
+                                        Toast.makeText(
+                                            context,
+                                            "Not connected to Wi-Fi",
+                                            Toast.LENGTH_SHORT
+                                        ).show()
+                                        serverState = "Disconnected"
+                                    } else {
+                                        scope.launch {
+                                            try {
+                                                val s = withContext(Dispatchers.IO) {
+                                                    Socket().apply {
+                                                        connect(
+                                                            InetSocketAddress(ip.substringBefore(":"), portPart),
+                                                            5000
+                                                        )
+                                                    }
                                                 }
+                                                socket = s
+                                                serverState = "Connected"
+                                            } catch (e: IOException) {
+                                                serverState = "Connection Failed"
+                                            } catch (e: Exception) {
+                                                serverState = "Encountered Error (${e.message})"
                                             }
-                                            socket = s
-                                            serverState = "Connected"
-                                        } catch (e: IOException) {
-                                            serverState = "Connection Failed"
-                                        } catch (e: Exception) {
-                                            serverState = "Encountered Error (${e.message})"
                                         }
                                     }
+                                } catch (e: SecurityException) {
+                                    serverState = "Encountered Error (${e.message})"
                                 }
                             }
                         }

--- a/app/src/main/java/com/lnkv/nfcemulator/ScenarioManager.kt
+++ b/app/src/main/java/com/lnkv/nfcemulator/ScenarioManager.kt
@@ -1,0 +1,24 @@
+package com.lnkv.nfcemulator
+
+import android.content.Context
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+
+object ScenarioManager {
+    private const val PREFS = "scenario_prefs"
+    private const val CURRENT_KEY = "currentScenario"
+
+    private val _current = MutableStateFlow<String?>(null)
+    val current = _current.asStateFlow()
+
+    fun load(context: Context) {
+        val prefs = context.getSharedPreferences(PREFS, Context.MODE_PRIVATE)
+        _current.value = prefs.getString(CURRENT_KEY, null)
+    }
+
+    fun setCurrent(context: Context, name: String?) {
+        _current.value = name
+        val prefs = context.getSharedPreferences(PREFS, Context.MODE_PRIVATE)
+        prefs.edit().putString(CURRENT_KEY, name).apply()
+    }
+}

--- a/app/src/main/java/com/lnkv/nfcemulator/ServerConnectionManager.kt
+++ b/app/src/main/java/com/lnkv/nfcemulator/ServerConnectionManager.kt
@@ -1,0 +1,106 @@
+package com.lnkv.nfcemulator
+
+import android.content.Context
+import android.net.ConnectivityManager
+import android.net.NetworkCapabilities
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import java.io.IOException
+import java.net.InetSocketAddress
+import java.net.Socket
+
+object ServerConnectionManager {
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Main)
+
+    var state by mutableStateOf("Disconnected")
+        private set
+    var isProcessing by mutableStateOf(false)
+        private set
+
+    private var socket: Socket? = null
+    private var currentIp: String? = null
+    private var currentPort: Int? = null
+
+    fun connect(context: Context, ip: String, port: Int) {
+        if (isProcessing) return
+        currentIp = ip
+        currentPort = port
+        state = "Connecting..."
+        isProcessing = true
+        scope.launch {
+            try {
+                val connectivityManager = context.getSystemService(Context.CONNECTIVITY_SERVICE) as? ConnectivityManager
+                val wifiConnected = connectivityManager
+                    ?.getNetworkCapabilities(connectivityManager.activeNetwork)
+                    ?.hasTransport(NetworkCapabilities.TRANSPORT_WIFI) == true
+                if (!wifiConnected) {
+                    state = "Disconnected"
+                    CommunicationLog.add("STATE-EXT: Server Connection $ip:$port Failed.", true)
+                } else {
+                    try {
+                        val s = withContext(Dispatchers.IO) {
+                            Socket().apply {
+                                connect(InetSocketAddress(ip, port), 5000)
+                            }
+                        }
+                        socket = s
+                        state = "Connected"
+                        CommunicationLog.add("STATE-EXT: Server Connection $ip:$port Success.", true)
+                    } catch (e: IOException) {
+                        state = "Connection Failed"
+                        CommunicationLog.add("STATE-EXT: Server Connection $ip:$port Failed.", true)
+                    } catch (e: Exception) {
+                        state = "Encountered Error (${e.message})"
+                        CommunicationLog.add(
+                            "STATE-EXT: Server Connection $ip:$port Error (${e.message}).",
+                            true
+                        )
+                    }
+                }
+            } catch (e: SecurityException) {
+                state = "Encountered Error (${e.message})"
+                CommunicationLog.add(
+                    "STATE-EXT: Server Connection $ip:$port Error (${e.message}).",
+                    true
+                )
+            } finally {
+                isProcessing = false
+            }
+        }
+    }
+
+    fun disconnect() {
+        if (isProcessing) return
+        val ip = currentIp
+        val port = currentPort
+        state = "Connecting..."
+        isProcessing = true
+        scope.launch {
+            try {
+                withContext(Dispatchers.IO) { socket?.close() }
+            } catch (_: Exception) {
+            } finally {
+                socket = null
+                currentIp = null
+                currentPort = null
+                state = "Disconnected"
+                isProcessing = false
+                if (ip != null && port != null) {
+                    CommunicationLog.add(
+                        "STATE-EXT: Server Connection $ip:$port Disconnected.",
+                        true
+                    )
+                } else {
+                    CommunicationLog.add("STATE-EXT: Server Connection Disconnected.", true)
+                }
+            }
+        }
+    }
+}
+

--- a/app/src/main/java/com/lnkv/nfcemulator/cardservice/TypeAEmulatorService.kt
+++ b/app/src/main/java/com/lnkv/nfcemulator/cardservice/TypeAEmulatorService.kt
@@ -21,7 +21,7 @@ class TypeAEmulatorService : HostApduService() {
 
         val apduHex = commandApdu.toHex()
         Log.d(TAG, "APDU: $apduHex")
-        CommunicationLog.add("REQ: $apduHex", true)
+        CommunicationLog.add("REQ: $apduHex", false)
 
         val response = if (isSelectCommand(commandApdu)) SELECT_OK else UNKNOWN_COMMAND
         CommunicationLog.add("RESP: ${response.toHex()}", false)

--- a/app/src/test/java/com/lnkv/nfcemulator/CommunicationLogTest.kt
+++ b/app/src/test/java/com/lnkv/nfcemulator/CommunicationLogTest.kt
@@ -20,7 +20,8 @@ class CommunicationLogTest {
         CommunicationLog.add("DATA", true)
         val entries = CommunicationLog.entries.value
         assertEquals(1, entries.size)
-        assertEquals(CommunicationLog.Entry("DATA", true), entries[0])
+        assertEquals("DATA", entries[0].message)
+        assertEquals(true, entries[0].isServer)
     }
 
     @Test

--- a/app/src/test/java/com/lnkv/nfcemulator/CommunicationScreenTest.kt
+++ b/app/src/test/java/com/lnkv/nfcemulator/CommunicationScreenTest.kt
@@ -21,11 +21,11 @@ class CommunicationScreenTest {
         )
 
         composeTestRule.setContent {
-            CommunicationScreen(entries)
+            CommunicationScreen(entries, currentScenario = null)
         }
 
-        composeTestRule.onNodeWithText("0102").assertExists()
-        composeTestRule.onNodeWithText("A1B2").assertExists()
+        composeTestRule.onNodeWithText("0102", substring = true).assertExists()
+        composeTestRule.onNodeWithText("A1B2", substring = true).assertExists()
     }
 
     @Test
@@ -36,7 +36,7 @@ class CommunicationScreenTest {
         )
 
         composeTestRule.setContent {
-            CommunicationScreen(entries)
+            CommunicationScreen(entries, currentScenario = null)
         }
 
         val heightBoth = composeTestRule.onNodeWithTag("ServerLog").fetchSemanticsNode().size.height
@@ -44,12 +44,12 @@ class CommunicationScreenTest {
         composeTestRule.waitForIdle()
         val heightSingle = composeTestRule.onNodeWithTag("ServerLog").fetchSemanticsNode().size.height
         assertTrue(heightSingle > heightBoth)
-        composeTestRule.onNodeWithText("A1B2").assertDoesNotExist()
+        composeTestRule.onNodeWithText("A1B2", substring = true).assertDoesNotExist()
     }
 
     @Test
     fun dividerMatchesLogWidth() {
-        composeTestRule.setContent { CommunicationScreen(emptyList()) }
+        composeTestRule.setContent { CommunicationScreen(emptyList(), currentScenario = null) }
 
         val logWidth = composeTestRule.onNodeWithTag("ServerLog").fetchSemanticsNode().size.width
         val dividerWidth = composeTestRule.onNodeWithTag("ToggleDivider").fetchSemanticsNode().size.width
@@ -59,14 +59,14 @@ class CommunicationScreenTest {
 
     @Test
     fun actionButtonsDisplayed() {
-        composeTestRule.setContent { CommunicationScreen(emptyList()) }
+        composeTestRule.setContent { CommunicationScreen(emptyList(), currentScenario = null) }
         composeTestRule.onNodeWithTag("SaveButton").assertExists()
         composeTestRule.onNodeWithTag("ClearButton").assertExists()
     }
 
     @Test
     fun actionButtonsMatchLogWidth() {
-        composeTestRule.setContent { CommunicationScreen(emptyList()) }
+        composeTestRule.setContent { CommunicationScreen(emptyList(), currentScenario = null) }
 
         val logWidth = composeTestRule.onNodeWithTag("ServerLog").fetchSemanticsNode().size.width
         val spacing = with(composeTestRule.density) { 8.dp.roundToPx() }
@@ -80,7 +80,7 @@ class CommunicationScreenTest {
 
     @Test
     fun segmentsFillWidth() {
-        composeTestRule.setContent { CommunicationScreen(emptyList()) }
+        composeTestRule.setContent { CommunicationScreen(emptyList(), currentScenario = null) }
 
         val rootWidth = composeTestRule.onRoot().fetchSemanticsNode().size.width
         val expectedWidth = rootWidth - with(composeTestRule.density) { 32.dp.roundToPx() }

--- a/app/src/test/java/com/lnkv/nfcemulator/CommunicationScreenTest.kt
+++ b/app/src/test/java/com/lnkv/nfcemulator/CommunicationScreenTest.kt
@@ -21,7 +21,7 @@ class CommunicationScreenTest {
         )
 
         composeTestRule.setContent {
-            CommunicationScreen(entries, currentScenario = null)
+            CommunicationScreen(entries, currentScenario = null, onClearScenario = {})
         }
 
         composeTestRule.onNodeWithText("0102", substring = true).assertExists()
@@ -36,7 +36,7 @@ class CommunicationScreenTest {
         )
 
         composeTestRule.setContent {
-            CommunicationScreen(entries, currentScenario = null)
+            CommunicationScreen(entries, currentScenario = null, onClearScenario = {})
         }
 
         val heightBoth = composeTestRule.onNodeWithTag("ServerLog").fetchSemanticsNode().size.height
@@ -49,7 +49,7 @@ class CommunicationScreenTest {
 
     @Test
     fun dividerMatchesLogWidth() {
-        composeTestRule.setContent { CommunicationScreen(emptyList(), currentScenario = null) }
+        composeTestRule.setContent { CommunicationScreen(emptyList(), currentScenario = null, onClearScenario = {}) }
 
         val logWidth = composeTestRule.onNodeWithTag("ServerLog").fetchSemanticsNode().size.width
         val dividerWidth = composeTestRule.onNodeWithTag("ToggleDivider").fetchSemanticsNode().size.width
@@ -59,14 +59,14 @@ class CommunicationScreenTest {
 
     @Test
     fun actionButtonsDisplayed() {
-        composeTestRule.setContent { CommunicationScreen(emptyList(), currentScenario = null) }
+        composeTestRule.setContent { CommunicationScreen(emptyList(), currentScenario = null, onClearScenario = {}) }
         composeTestRule.onNodeWithTag("SaveButton").assertExists()
         composeTestRule.onNodeWithTag("ClearButton").assertExists()
     }
 
     @Test
     fun actionButtonsMatchLogWidth() {
-        composeTestRule.setContent { CommunicationScreen(emptyList(), currentScenario = null) }
+        composeTestRule.setContent { CommunicationScreen(emptyList(), currentScenario = null, onClearScenario = {}) }
 
         val logWidth = composeTestRule.onNodeWithTag("ServerLog").fetchSemanticsNode().size.width
         val spacing = with(composeTestRule.density) { 8.dp.roundToPx() }
@@ -80,7 +80,7 @@ class CommunicationScreenTest {
 
     @Test
     fun segmentsFillWidth() {
-        composeTestRule.setContent { CommunicationScreen(emptyList(), currentScenario = null) }
+        composeTestRule.setContent { CommunicationScreen(emptyList(), currentScenario = null, onClearScenario = {}) }
 
         val rootWidth = composeTestRule.onRoot().fetchSemanticsNode().size.width
         val expectedWidth = rootWidth - with(composeTestRule.density) { 32.dp.roundToPx() }
@@ -91,9 +91,17 @@ class CommunicationScreenTest {
 
     @Test
     fun lastSegmentDisables() {
-        composeTestRule.setContent { CommunicationScreen(emptyList()) }
+        composeTestRule.setContent { CommunicationScreen(emptyList(), currentScenario = null, onClearScenario = {}) }
         composeTestRule.onNodeWithTag("NfcToggle").performClick()
         composeTestRule.onNodeWithTag("ServerToggle").assertIsNotEnabled()
+    }
+
+    @Test
+    fun scenarioClearButtonShown() {
+        composeTestRule.setContent {
+            CommunicationScreen(emptyList(), currentScenario = "S1", onClearScenario = {})
+        }
+        composeTestRule.onNodeWithTag("ScenarioClearButton").assertExists()
     }
 }
 

--- a/app/src/test/java/com/lnkv/nfcemulator/ScenarioScreenTest.kt
+++ b/app/src/test/java/com/lnkv/nfcemulator/ScenarioScreenTest.kt
@@ -6,6 +6,7 @@ import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performTextInput
 import androidx.compose.ui.test.assertExists
 import org.junit.Rule
 import org.junit.Test
@@ -18,6 +19,9 @@ class ScenarioScreenTest {
     fun editButtonEnabledWhenScenarioSelected() {
         composeTestRule.setContent { ScenarioScreen() }
         composeTestRule.onNodeWithTag("ScenarioEdit").assertIsNotEnabled()
+        composeTestRule.onNodeWithTag("ScenarioNew").performClick()
+        composeTestRule.onNodeWithTag("ScenarioTitle").performTextInput("S1")
+        composeTestRule.onNodeWithTag("ScenarioSave").performClick()
         composeTestRule.onNodeWithTag("ScenarioItem0").performClick()
         composeTestRule.onNodeWithTag("ScenarioEdit").assertIsEnabled()
     }

--- a/app/src/test/java/com/lnkv/nfcemulator/ScenarioScreenTest.kt
+++ b/app/src/test/java/com/lnkv/nfcemulator/ScenarioScreenTest.kt
@@ -46,4 +46,15 @@ class ScenarioScreenTest {
         composeTestRule.setContent { ScenarioScreen() }
         composeTestRule.onNodeWithTag("ScenarioList").assertExists()
     }
+
+    @Test
+    fun scenarioRemainsAfterPlay() {
+        composeTestRule.setContent { ScenarioScreen() }
+        composeTestRule.onNodeWithTag("ScenarioNew").performClick()
+        composeTestRule.onNodeWithTag("ScenarioTitle").performTextInput("S1")
+        composeTestRule.onNodeWithTag("ScenarioSave").performClick()
+        composeTestRule.onNodeWithTag("ScenarioItem0").performClick()
+        composeTestRule.onNodeWithTag("ScenarioPlay0").performClick()
+        composeTestRule.onNodeWithTag("ScenarioItem0").assertExists()
+    }
 }

--- a/app/src/test/java/com/lnkv/nfcemulator/ServerScreenTest.kt
+++ b/app/src/test/java/com/lnkv/nfcemulator/ServerScreenTest.kt
@@ -14,10 +14,19 @@ import androidx.compose.ui.test.assertTextEquals
 import androidx.compose.ui.test.performClick
 import org.junit.Rule
 import org.junit.Test
+import org.junit.Before
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
 
 class ServerScreenTest {
     @get:Rule
     val composeTestRule = createComposeRule()
+
+    @Before
+    fun setup() {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        context.getSharedPreferences("server_prefs", Context.MODE_PRIVATE).edit().clear().apply()
+    }
 
     @Test
     fun ipClearWorks() {
@@ -79,6 +88,7 @@ class ServerScreenTest {
         composeTestRule.setContent { ServerScreen() }
         composeTestRule.onNodeWithTag("ServerState").assertTextEquals("Server State: Disconnected")
         composeTestRule.onNodeWithTag("ConnectButton").performClick()
+        composeTestRule.waitForIdle()
         composeTestRule.onNodeWithTag("ServerState").assertTextEquals("Server State: Disconnected")
     }
 
@@ -86,6 +96,7 @@ class ServerScreenTest {
     fun externalFieldsRemainEnabledOnFailedConnection() {
         composeTestRule.setContent { ServerScreen() }
         composeTestRule.onNodeWithTag("ConnectButton").performClick()
+        composeTestRule.waitForIdle()
         composeTestRule.onNodeWithTag("IpField").assertIsEnabled()
         composeTestRule.onNodeWithTag("PollingField").assertIsEnabled()
         composeTestRule.onNodeWithTag("AutoConnectCheck").assertIsEnabled()
@@ -98,6 +109,7 @@ class ServerScreenTest {
         composeTestRule.onNodeWithTag("IpClear").performClick()
         composeTestRule.onNodeWithTag("PollingClear").performClick()
         composeTestRule.onNodeWithTag("ConnectButton").performClick()
+        composeTestRule.waitForIdle()
         composeTestRule.onNodeWithTag("ServerState").assertTextEquals("Server State: Disconnected")
     }
 
@@ -108,6 +120,7 @@ class ServerScreenTest {
         field.performTextClearance()
         field.performTextInput("192.168.0.1")
         composeTestRule.onNodeWithTag("ConnectButton").performClick()
+        composeTestRule.waitForIdle()
         composeTestRule.onNodeWithTag("ServerState").assertTextEquals("Server State: Disconnected")
     }
 

--- a/app/src/test/java/com/lnkv/nfcemulator/ServerScreenTest.kt
+++ b/app/src/test/java/com/lnkv/nfcemulator/ServerScreenTest.kt
@@ -75,23 +75,21 @@ class ServerScreenTest {
     }
 
     @Test
-    fun connectButtonTogglesState() {
+    fun connectButtonRequiresWifi() {
         composeTestRule.setContent { ServerScreen() }
         composeTestRule.onNodeWithTag("ServerState").assertTextEquals("Server State: Disconnected")
-        composeTestRule.onNodeWithTag("ConnectButton").performClick()
-        composeTestRule.onNodeWithTag("ServerState").assertTextEquals("Server State: Connected")
         composeTestRule.onNodeWithTag("ConnectButton").performClick()
         composeTestRule.onNodeWithTag("ServerState").assertTextEquals("Server State: Disconnected")
     }
 
     @Test
-    fun externalFieldsDisabledWhenConnected() {
+    fun externalFieldsRemainEnabledOnFailedConnection() {
         composeTestRule.setContent { ServerScreen() }
         composeTestRule.onNodeWithTag("ConnectButton").performClick()
-        composeTestRule.onNodeWithTag("IpField").assertIsNotEnabled()
-        composeTestRule.onNodeWithTag("PollingField").assertIsNotEnabled()
-        composeTestRule.onNodeWithTag("AutoConnectCheck").assertIsNotEnabled()
-        composeTestRule.onNodeWithTag("SaveServer").assertIsNotEnabled()
+        composeTestRule.onNodeWithTag("IpField").assertIsEnabled()
+        composeTestRule.onNodeWithTag("PollingField").assertIsEnabled()
+        composeTestRule.onNodeWithTag("AutoConnectCheck").assertIsEnabled()
+        composeTestRule.onNodeWithTag("SaveServer").assertIsEnabled()
     }
 
     @Test

--- a/app/src/test/java/com/lnkv/nfcemulator/cardservice/TypeAEmulatorServiceTest.kt
+++ b/app/src/test/java/com/lnkv/nfcemulator/cardservice/TypeAEmulatorServiceTest.kt
@@ -27,9 +27,9 @@ class TypeAEmulatorServiceTest {
         assertArrayEquals(byteArrayOf(0x90.toByte(), 0x00.toByte()), response)
         val entries = CommunicationLog.entries.value
         assertEquals("REQ: 00A40400", entries[0].message)
-        assertEquals(true, entries[0].isRequest)
+        assertEquals(false, entries[0].isServer)
         assertEquals("RESP: 9000", entries[1].message)
-        assertEquals(false, entries[1].isRequest)
+        assertEquals(false, entries[1].isServer)
     }
 
     @Test

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -26,6 +26,7 @@ androidx-ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-test-junit
 androidx-material3 = { group = "androidx.compose.material3", name = "material3" }
 androidx-runtime-saveable = { group = "androidx.compose.runtime", name = "runtime-saveable" }
 androidx-material-icons-extended = { group = "androidx.compose.material", name = "material-icons-extended" }
+androidx-test-core = { group = "androidx.test", name = "core", version = "1.5.0" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
## Summary
- Persist scenarios via SharedPreferences and remove hardcoded defaults
- Default server IP/port to zeros and store server settings
- Implement Wi-Fi socket connection with detailed server state

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy, HTTP/1.1 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68a5a57e62a48330a3925e811b28619e