### PR TITLE
Add AID management screen and server coordination

### DIFF
--- a/app/src/main/java/com/lnkv/nfcemulator/MainActivity.kt
+++ b/app/src/main/java/com/lnkv/nfcemulator/MainActivity.kt
@@ -161,11 +161,18 @@ class MainActivity : ComponentActivity() {
     }
 
     private fun registerAids(aids: List<String>) {
-        cardEmulation.registerAidsForService(
-            componentName,
-            CardEmulation.CATEGORY_OTHER,
-            aids
-        )
+        if (aids.isEmpty()) {
+            cardEmulation.removeAidsForService(
+                componentName,
+                CardEmulation.CATEGORY_OTHER
+            )
+        } else {
+            cardEmulation.registerAidsForService(
+                componentName,
+                CardEmulation.CATEGORY_OTHER,
+                aids
+            )
+        }
     }
 }
 
@@ -1263,11 +1270,16 @@ private fun saveAids(context: Context, aids: List<String>) {
     prefs.edit().putStringSet(AID_KEY, aids.toSet()).apply()
     val nfcAdapter = NfcAdapter.getDefaultAdapter(context)
     val cardEmulation = CardEmulation.getInstance(nfcAdapter)
-    cardEmulation.registerAidsForService(
-        ComponentName(context, TypeAEmulatorService::class.java),
-        CardEmulation.CATEGORY_OTHER,
-        aids
-    )
+    val component = ComponentName(context, TypeAEmulatorService::class.java)
+    if (aids.isEmpty()) {
+        cardEmulation.removeAidsForService(component, CardEmulation.CATEGORY_OTHER)
+    } else {
+        cardEmulation.registerAidsForService(
+            component,
+            CardEmulation.CATEGORY_OTHER,
+            aids
+        )
+    }
 }
 
 private fun exportAids(context: Context, aids: List<String>, uri: Uri) {

--- a/app/src/main/java/com/lnkv/nfcemulator/MainActivity.kt
+++ b/app/src/main/java/com/lnkv/nfcemulator/MainActivity.kt
@@ -498,7 +498,7 @@ fun StepEditor(
  * Navigation targets displayed in the bottom bar.
  */
 enum class Screen(val label: String) {
-    Communication("Communication"),
+    Communication("Comm"),
     Scenario("Scenarios"),
     Server("Server"),
     Aid("AID")
@@ -687,6 +687,7 @@ fun MainScreen() {
                   CommunicationScreen(
                       logEntries,
                       currentScenario,
+                      onRunScenario = { name -> ScenarioManager.setCurrent(context, name) },
                       onClearScenario = { ScenarioManager.setCurrent(context, null) },
                       modifier = Modifier.padding(padding)
                   )
@@ -712,6 +713,7 @@ fun MainScreen() {
 fun CommunicationScreen(
     entries: List<CommunicationLog.Entry>,
     currentScenario: String?,
+    onRunScenario: (String) -> Unit,
     onClearScenario: () -> Unit,
     modifier: Modifier = Modifier
 ) {
@@ -748,12 +750,21 @@ fun CommunicationScreen(
                 "Current Scenario: ${currentScenario ?: "None"}",
                 modifier = Modifier.weight(1f)
             )
-            Button(
-                onClick = onClearScenario,
-                enabled = currentScenario != null,
-                modifier = Modifier.testTag("ScenarioClearButton")
-            ) {
-                Text("Clear")
+            Row(horizontalArrangement = Arrangement.spacedBy(8.dp), verticalAlignment = Alignment.CenterVertically) {
+                Button(
+                    onClick = { currentScenario?.let(onRunScenario) },
+                    enabled = currentScenario != null,
+                    modifier = Modifier.testTag("ScenarioRunButton")
+                ) {
+                    Text("Run")
+                }
+                Button(
+                    onClick = onClearScenario,
+                    enabled = currentScenario != null,
+                    modifier = Modifier.testTag("ScenarioClearButton")
+                ) {
+                    Text("Clear")
+                }
             }
         }
         Spacer(modifier = Modifier.height(8.dp))

--- a/app/src/test/java/com/lnkv/nfcemulator/AidValidationTest.kt
+++ b/app/src/test/java/com/lnkv/nfcemulator/AidValidationTest.kt
@@ -1,0 +1,17 @@
+package com.lnkv.nfcemulator
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class AidValidationTest {
+    @Test
+    fun validAidIsAccepted() {
+        assertTrue(isValidAid("A0000002471001"))
+    }
+
+    @Test
+    fun invalidAidIsRejected() {
+        assertFalse(isValidAid("AAFFCCDD"))
+    }
+}

--- a/app/src/test/java/com/lnkv/nfcemulator/CommunicationScreenTest.kt
+++ b/app/src/test/java/com/lnkv/nfcemulator/CommunicationScreenTest.kt
@@ -21,7 +21,7 @@ class CommunicationScreenTest {
         )
 
         composeTestRule.setContent {
-            CommunicationScreen(entries, currentScenario = null, onClearScenario = {})
+            CommunicationScreen(entries, currentScenario = null, onRunScenario = {}, onClearScenario = {})
         }
 
         composeTestRule.onNodeWithText("0102", substring = true).assertExists()
@@ -36,7 +36,7 @@ class CommunicationScreenTest {
         )
 
         composeTestRule.setContent {
-            CommunicationScreen(entries, currentScenario = null, onClearScenario = {})
+            CommunicationScreen(entries, currentScenario = null, onRunScenario = {}, onClearScenario = {})
         }
 
         val heightBoth = composeTestRule.onNodeWithTag("ServerLog").fetchSemanticsNode().size.height
@@ -49,7 +49,7 @@ class CommunicationScreenTest {
 
     @Test
     fun dividerMatchesLogWidth() {
-        composeTestRule.setContent { CommunicationScreen(emptyList(), currentScenario = null, onClearScenario = {}) }
+        composeTestRule.setContent { CommunicationScreen(emptyList(), currentScenario = null, onRunScenario = {}, onClearScenario = {}) }
 
         val logWidth = composeTestRule.onNodeWithTag("ServerLog").fetchSemanticsNode().size.width
         val dividerWidth = composeTestRule.onNodeWithTag("ToggleDivider").fetchSemanticsNode().size.width
@@ -59,14 +59,14 @@ class CommunicationScreenTest {
 
     @Test
     fun actionButtonsDisplayed() {
-        composeTestRule.setContent { CommunicationScreen(emptyList(), currentScenario = null, onClearScenario = {}) }
+        composeTestRule.setContent { CommunicationScreen(emptyList(), currentScenario = null, onRunScenario = {}, onClearScenario = {}) }
         composeTestRule.onNodeWithTag("SaveButton").assertExists()
         composeTestRule.onNodeWithTag("ClearButton").assertExists()
     }
 
     @Test
     fun actionButtonsMatchLogWidth() {
-        composeTestRule.setContent { CommunicationScreen(emptyList(), currentScenario = null, onClearScenario = {}) }
+        composeTestRule.setContent { CommunicationScreen(emptyList(), currentScenario = null, onRunScenario = {}, onClearScenario = {}) }
 
         val logWidth = composeTestRule.onNodeWithTag("ServerLog").fetchSemanticsNode().size.width
         val spacing = with(composeTestRule.density) { 8.dp.roundToPx() }
@@ -80,7 +80,7 @@ class CommunicationScreenTest {
 
     @Test
     fun segmentsFillWidth() {
-        composeTestRule.setContent { CommunicationScreen(emptyList(), currentScenario = null, onClearScenario = {}) }
+        composeTestRule.setContent { CommunicationScreen(emptyList(), currentScenario = null, onRunScenario = {}, onClearScenario = {}) }
 
         val rootWidth = composeTestRule.onRoot().fetchSemanticsNode().size.width
         val expectedWidth = rootWidth - with(composeTestRule.density) { 32.dp.roundToPx() }
@@ -91,7 +91,7 @@ class CommunicationScreenTest {
 
     @Test
     fun lastSegmentDisables() {
-        composeTestRule.setContent { CommunicationScreen(emptyList(), currentScenario = null, onClearScenario = {}) }
+        composeTestRule.setContent { CommunicationScreen(emptyList(), currentScenario = null, onRunScenario = {}, onClearScenario = {}) }
         composeTestRule.onNodeWithTag("NfcToggle").performClick()
         composeTestRule.onNodeWithTag("ServerToggle").assertIsNotEnabled()
     }
@@ -99,9 +99,22 @@ class CommunicationScreenTest {
     @Test
     fun scenarioClearButtonShown() {
         composeTestRule.setContent {
-            CommunicationScreen(emptyList(), currentScenario = "S1", onClearScenario = {})
+            CommunicationScreen(emptyList(), currentScenario = "S1", onRunScenario = {}, onClearScenario = {})
         }
         composeTestRule.onNodeWithTag("ScenarioClearButton").assertExists()
+    }
+
+    @Test
+    fun scenarioRunButtonState() {
+        composeTestRule.setContent {
+            CommunicationScreen(emptyList(), currentScenario = null, onRunScenario = {}, onClearScenario = {})
+        }
+        composeTestRule.onNodeWithTag("ScenarioRunButton").assertIsNotEnabled()
+
+        composeTestRule.setContent {
+            CommunicationScreen(emptyList(), currentScenario = "S1", onRunScenario = {}, onClearScenario = {})
+        }
+        composeTestRule.onNodeWithTag("ScenarioRunButton").assertIsEnabled()
     }
 }
 

--- a/app/src/test/java/com/lnkv/nfcemulator/MainScreenTest.kt
+++ b/app/src/test/java/com/lnkv/nfcemulator/MainScreenTest.kt
@@ -12,7 +12,7 @@ class MainScreenTest {
     @Test
     fun navigationIconsPresent() {
         composeTestRule.setContent { MainScreen() }
-        composeTestRule.onNodeWithContentDescription("Communication").assertExists()
+        composeTestRule.onNodeWithContentDescription("Comm").assertExists()
         composeTestRule.onNodeWithContentDescription("Scenarios").assertExists()
         composeTestRule.onNodeWithContentDescription("Server").assertExists()
         composeTestRule.onNodeWithContentDescription("AID").assertExists()

--- a/app/src/test/java/com/lnkv/nfcemulator/MainScreenTest.kt
+++ b/app/src/test/java/com/lnkv/nfcemulator/MainScreenTest.kt
@@ -15,5 +15,6 @@ class MainScreenTest {
         composeTestRule.onNodeWithContentDescription("Communication").assertExists()
         composeTestRule.onNodeWithContentDescription("Scenarios").assertExists()
         composeTestRule.onNodeWithContentDescription("Server").assertExists()
+        composeTestRule.onNodeWithContentDescription("AID").assertExists()
     }
 }


### PR DESCRIPTION
## Summary
- add AID section with add/remove/import/export and dynamic registration
- start internal server automatically on Wi-Fi and stop external connection
- stop internal server when connecting to external server and add scenario dividers

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68a8a0f053e4833083570b2b3d943fc5