### PR TITLE
Add example external control server

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,9 +137,9 @@ completed before the request is matched.
 ## Example external server
 
 A minimal Node.js implementation of this HTTP API is provided in
-[`example-server/`](example-server/). It allows controlling the app from a
-desktop machine or other external tools and handles multiple commands
-concurrently.
+[`example-server/`](example-server/). `POST /` requests queue command payloads
+and the app retrieves them by polling `GET /`. The server logs each request to
+stdout so you can see when commands are queued and dispatched.
 
 ## Code Structure
 

--- a/README.md
+++ b/README.md
@@ -35,40 +35,52 @@ with a JSON body to `http://<DEVICE_IP>:<PORT>/`.
 
 ### Command structure
 
-Each request must contain a top-level `Type` field that determines the payload:
+Commands are grouped by top-level keys. A request may include any combination of
+the following objects: `Aid`, `Comm`, `Scenarios`, `Filters`, and `Reset`.
+Each object mirrors the fields described below. For compatibility, older
+payloads that use a single `Type` field are still accepted.
 
-#### `Type: "Aid"`
+Example combining AID registration and log clearing:
+
+```bash
+curl -X POST http://<DEVICE_IP>:<PORT>/ -H "Content-Type: application/json" \
+  -d '{"Aid":{"Add":"A0000002471001"},"Comm":{"Clear":true}}'
+```
+
+#### `Aid`
 
 Manage registered Application Identifiers.
 
 ```json
 {
-  "Type": "Aid",
-  "Add": ["A0000002471001", "A0000002471002"],   // optional AIDs to add
-  "Remove": ["A0000002471003"],                  // optional AIDs to remove
-  "Clear": false                                 // set true to unregister all AIDs
+  "Aid": {
+    "Add": ["A0000002471001", "A0000002471002"],   // optional AIDs to add
+    "Remove": ["A0000002471003"],                  // optional AIDs to remove
+    "Clear": false                                 // set true to unregister all AIDs
+  }
 }
 ```
 `Add` and `Remove` accept either a single string or an array of strings.
 
-#### `Type: "Comm"`
+#### `Comm`
 
 Control the communication log and scenarios.
 
 ```json
 {
-  "Type": "Comm",
-  "Clear": false,            // clear the log when true
-  "Save": true,              // save log to file when true
-  "Mute": false,             // mute/unmute communication
-  "CurrentScenario": "Start" // "Start", "Stop" or "Clear"
+  "Comm": {
+    "Clear": false,            // clear the log when true
+    "Save": true,              // save log to file when true
+    "Mute": false,             // mute/unmute communication
+    "CurrentScenario": "Start" // "Start", "Stop" or "Clear"
+  }
 }
 ```
 
 Requests receive a simple `200 OK` response. Additional command types may be
 introduced in future versions.
 
-#### `Type: "Scenarios"`
+#### `Scenarios`
 
 Create or manage scenarios.
 Steps may be of type `Select`, which waits for an AID selection, or
@@ -78,11 +90,11 @@ completed before the request is matched.
 
 ```json
 {
-  "Type": "Scenarios",
-  "Add": [
-    {
-      "name": "MyScenario",
-      "steps": [
+  "Scenarios": {
+    "Add": [
+      {
+        "name": "MyScenario",
+        "steps": [
         {
           "name": "Select",
           "type": "Select",
@@ -98,10 +110,11 @@ completed before the request is matched.
         }
       ]
     }
-  ],
-  "Remove": ["OldScenario"],    // optional names to remove
-  "Clear": false,                // clear all scenarios when true
-  "Current": "MyScenario"       // set current scenario
+    ],
+    "Remove": ["OldScenario"],    // optional names to remove
+    "Clear": false,                // clear all scenarios when true
+    "Current": "MyScenario"       // set current scenario
+  }
 }
 ```
 `Add` and `Remove` accept arrays; `Add` may also be a single scenario object and `Remove` a single name.

--- a/README.md
+++ b/README.md
@@ -106,6 +106,13 @@ completed before the request is matched.
 ```
 `Add` and `Remove` accept arrays; `Add` may also be a single scenario object and `Remove` a single name.
 
+## Example external server
+
+A minimal Node.js implementation of this HTTP API is provided in
+[`example-server/`](example-server/). It allows controlling the app from a
+desktop machine or other external tools and handles multiple commands
+concurrently.
+
 ## Code Structure
 
 - `MainActivity` – Compose UI and AID configuration.

--- a/README.md
+++ b/README.md
@@ -52,6 +52,16 @@ curl -X POST http://<DEVICE_IP>:<PORT>/ -H "Content-Type: application/json" \
   -d '{"Aid":{"Add":"A0000002471001"},"Comm":{"Clear":true}}'
 ```
 
+For a broader example that registers AIDs, adds a scenario, applies a filter and
+clears the log in one request, see
+[`example-server/multi-command-request.json`](example-server/multi-command-request.json)
+and post it with:
+
+```bash
+curl -X POST http://<DEVICE_IP>:<PORT>/ -H "Content-Type: application/json" \
+  -d @example-server/multi-command-request.json
+```
+
 #### `Aid`
 
 Manage registered Application Identifiers.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,12 @@
 # NFC Type A Emulator – Android App
 
-An Android application for emulating **NFC Type A** cards (ISO 14443-3A / ISO 14443-4A) using compatible devices.
-The app allows developers, researchers, and hobbyists to test NFC readers without requiring the original physical card.
+## About
+NFC Type A Emulator is an Android application for emulating **NFC Type A**
+cards (ISO 14443-3A / ISO 14443-4A) using compatible devices. It lets
+developers, researchers, and hobbyists test NFC readers without requiring the
+original physical card. The app exposes an HTTP API that can be driven from the
+device itself or from the included Node.js external server, and both accept a
+single request containing multiple command groups.
 
 ## Prerequisites
 

--- a/app/src/main/java/com/lnkv/nfcemulator/InternalServerManager.kt
+++ b/app/src/main/java/com/lnkv/nfcemulator/InternalServerManager.kt
@@ -41,6 +41,7 @@ object InternalServerManager {
                         clients[id] = socket
                         CommunicationLog.add("STATE-INT: Device $id started transmission.", true, true)
                         launch {
+                            var cleared = false
                             try {
                                 val reader = socket.getInputStream().bufferedReader()
                                 val headers = mutableListOf<String>()
@@ -63,7 +64,7 @@ object InternalServerManager {
                                 Log.d(TAG, "request: $body")
                                 if (body.isNotBlank()) {
                                     CommunicationLog.add("POST: $body", true, true)
-                                    ServerJsonHandler.handle(body)
+                                    cleared = ServerJsonHandler.handle(body)
                                 }
                                 try {
                                     socket.getOutputStream().apply {
@@ -76,7 +77,9 @@ object InternalServerManager {
                                 Log.d(TAG, "client error: ${e.message}")
                             } finally {
                                 clients.remove(id)
-                                CommunicationLog.add("STATE-INT: Device $id finished transmission.", true, false)
+                                if (!cleared) {
+                                    CommunicationLog.add("STATE-INT: Device $id finished transmission.", true, false)
+                                }
                                 try { socket.close() } catch (_: Exception) {}
                             }
                         }

--- a/app/src/main/java/com/lnkv/nfcemulator/ServerJsonHandler.kt
+++ b/app/src/main/java/com/lnkv/nfcemulator/ServerJsonHandler.kt
@@ -15,13 +15,24 @@ object ServerJsonHandler {
         Log.d(TAG, "handle: $jsonStr")
         try {
             val obj = JSONObject(jsonStr)
-            when (obj.optString("Type")) {
-                "Aid" -> handleAid(obj)
-                "Comm" -> handleComm(obj)
-                "Scenarios" -> handleScenarios(obj)
-                "Filters" -> handleFilters(obj)
-                "Reset" -> handleReset()
+
+            val type = obj.optString("Type")
+            if (type.isNotBlank()) {
+                when (type) {
+                    "Aid" -> handleAid(obj)
+                    "Comm" -> handleComm(obj)
+                    "Scenarios" -> handleScenarios(obj)
+                    "Filters" -> handleFilters(obj)
+                    "Reset" -> handleReset()
+                }
+                return
             }
+
+            obj.optJSONObject("Aid")?.let { handleAid(it) }
+            obj.optJSONObject("Comm")?.let { handleComm(it) }
+            obj.optJSONObject("Scenarios")?.let { handleScenarios(it) }
+            obj.optJSONObject("Filters")?.let { handleFilters(it) }
+            if (obj.has("Reset")) handleReset()
         } catch (e: Exception) {
             Log.d(TAG, "parse error: ${e.message}")
             CommunicationLog.add("JSON ERR: ${e.message}", true, false)

--- a/app/src/test/java/com/lnkv/nfcemulator/ServerJsonHandlerMultiTypeTest.kt
+++ b/app/src/test/java/com/lnkv/nfcemulator/ServerJsonHandlerMultiTypeTest.kt
@@ -1,0 +1,28 @@
+package com.lnkv.nfcemulator
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+/** Verifies that multiple command types in one request are processed. */
+class ServerJsonHandlerMultiTypeTest {
+    private lateinit var context: Context
+
+    @Before
+    fun setup() {
+        context = ApplicationProvider.getApplicationContext()
+        AppContextHolder.init(context)
+        CommunicationLog.add("test", true)
+        CommunicationFilter.clear(context)
+    }
+
+    @Test
+    fun handlesMultipleSections() {
+        val json = "{\"Comm\":{\"Clear\":true},\"Filters\":{\"Add\":\"AABB\"}}"
+        ServerJsonHandler.handle(json)
+        assertTrue(CommunicationFilter.filters.value.contains("AABB"))
+        assertTrue(CommunicationLog.entries.value.isEmpty())
+    }
+}

--- a/app/src/test/java/com/lnkv/nfcemulator/ServerJsonHandlerMultiTypeTest.kt
+++ b/app/src/test/java/com/lnkv/nfcemulator/ServerJsonHandlerMultiTypeTest.kt
@@ -21,7 +21,8 @@ class ServerJsonHandlerMultiTypeTest {
     @Test
     fun handlesMultipleSections() {
         val json = "{\"Comm\":{\"Clear\":true},\"Filters\":{\"Add\":\"AABB\"}}"
-        ServerJsonHandler.handle(json)
+        val cleared = ServerJsonHandler.handle(json)
+        assertTrue(cleared)
         assertTrue(CommunicationFilter.filters.value.contains("AABB"))
         assertTrue(CommunicationLog.entries.value.isEmpty())
     }

--- a/example-server/README.md
+++ b/example-server/README.md
@@ -23,7 +23,9 @@ variable to change it.
 
 ## Endpoints
 
-All commands are sent as `POST` requests with a JSON body to the root path `/`.
+The app polls the server with `GET /` requests, to which the server responds
+with an empty body. When commands need to be executed, send them as `POST`
+requests with a JSON body to the root path `/`.
 The payload structure matches the [HTTP Control API](../README.md#http-control-api)
 of the app. Multiple command groups may be combined in one payload. Example:
 

--- a/example-server/README.md
+++ b/example-server/README.md
@@ -31,3 +31,13 @@ of the app. Multiple command groups may be combined in one payload. Example:
 curl -X POST http://localhost:1818/ -H "Content-Type: application/json" \
   -d '{"Aid":{"Add":"A0000002471001"},"Comm":{"Clear":true}}'
 ```
+
+For a more comprehensive demo, the repository includes
+[`multi-command-request.json`](multi-command-request.json) which registers two
+AIDs, adds a scenario, sets it as current, adds a communication filter and clears
+the log all at once:
+
+```bash
+curl -X POST http://localhost:1818/ -H "Content-Type: application/json" \
+  -d @multi-command-request.json
+```

--- a/example-server/README.md
+++ b/example-server/README.md
@@ -3,7 +3,7 @@
 This Node.js server demonstrates how an external controller can interact with
 the NFC Emulator app using the same JSON API exposed by the internal server.
 It keeps AIDs, scenarios and a communication log in memory and can handle
-multiple requests concurrently.
+multiple commands in a single request or concurrently across requests.
 
 ## Setup
 
@@ -25,9 +25,9 @@ variable to change it.
 
 All commands are sent as `POST` requests with a JSON body to the root path `/`.
 The payload structure matches the [HTTP Control API](../README.md#http-control-api)
-of the app. Example:
+of the app. Multiple command groups may be combined in one payload. Example:
 
 ```bash
 curl -X POST http://localhost:1818/ -H "Content-Type: application/json" \
-  -d '{"Type":"Aid","Add":"A0000002471001"}'
+  -d '{"Aid":{"Add":"A0000002471001"},"Comm":{"Clear":true}}'
 ```

--- a/example-server/README.md
+++ b/example-server/README.md
@@ -4,6 +4,8 @@ This Node.js server demonstrates how an external controller can interact with
 the NFC Emulator app using the same JSON API exposed by the internal server.
 It keeps AIDs, scenarios and a communication log in memory and can handle
 multiple commands in a single request or concurrently across requests.
+Each `POST /` queues a command payload and the app retrieves the next
+pending item with `GET /`.
 
 ## Setup
 
@@ -19,14 +21,17 @@ npm start
 ```
 
 The server listens on port `1818` by default. Use the `PORT` environment
-variable to change it.
+variable to change it. Every request is printed to the console for debugging.
 
 ## Endpoints
 
-The app polls the server with `GET /` requests, to which the server responds
-with an empty body. When commands need to be executed, send them as `POST`
-requests with a JSON body to the root path `/`.
-The payload structure matches the [HTTP Control API](../README.md#http-control-api)
+The app polls the server with `GET /` requests. If a queued command is
+available, the server responds with that JSON object and removes it from the
+queue; otherwise it returns an empty body.
+
+To enqueue commands, send them as `POST` requests with a JSON body to the root
+path `/`. The payload structure matches the
+[HTTP Control API](../README.md#http-control-api)
 of the app. Multiple command groups may be combined in one payload. Example:
 
 ```bash

--- a/example-server/README.md
+++ b/example-server/README.md
@@ -1,0 +1,33 @@
+# Example External Server
+
+This Node.js server demonstrates how an external controller can interact with
+the NFC Emulator app using the same JSON API exposed by the internal server.
+It keeps AIDs, scenarios and a communication log in memory and can handle
+multiple requests concurrently.
+
+## Setup
+
+```bash
+cd example-server
+npm install
+```
+
+## Running
+
+```bash
+npm start
+```
+
+The server listens on port `1818` by default. Use the `PORT` environment
+variable to change it.
+
+## Endpoints
+
+All commands are sent as `POST` requests with a JSON body to the root path `/`.
+The payload structure matches the [HTTP Control API](../README.md#http-control-api)
+of the app. Example:
+
+```bash
+curl -X POST http://localhost:1818/ -H "Content-Type: application/json" \
+  -d '{"Type":"Aid","Add":"A0000002471001"}'
+```

--- a/example-server/multi-command-request.json
+++ b/example-server/multi-command-request.json
@@ -1,0 +1,20 @@
+{
+  "Aid": {
+    "Clear": true,
+    "Add": ["A0000002471001", "A0000002471002"]
+  },
+  "Scenarios": {
+    "Add": [
+      {
+        "name": "SampleScenario",
+        "aid": "A0000002471001",
+        "steps": [
+          { "name": "Select", "request": "00A4040008A0000002471001", "response": "9000" }
+        ]
+      }
+    ],
+    "Current": "SampleScenario"
+  },
+  "Comm": { "Clear": true },
+  "Filters": { "Add": "A0B1" }
+}

--- a/example-server/package.json
+++ b/example-server/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "nfc-external-server",
+  "version": "1.0.0",
+  "description": "Example external server for the NFC emulator app.",
+  "main": "server.js",
+  "scripts": {
+    "start": "node server.js"
+  },
+  "dependencies": {
+    "express": "^4.18.2"
+  }
+}

--- a/example-server/server.js
+++ b/example-server/server.js
@@ -15,20 +15,32 @@ let logEntries = [];
 // Unified POST endpoint matching the app's internal server API.
 app.post('/', async (req, res) => {
   try {
-    const { Type } = req.body;
-    switch (Type) {
-      case 'Aid':
-        handleAid(req.body);
-        return res.status(HTTP_OK).json({ aids: Array.from(aids) });
-      case 'Comm':
-        handleComm(req.body);
-        return res.status(HTTP_OK).json({ logLength: logEntries.length });
-      case 'Scenarios':
-        handleScenarios(req.body);
-        return res.status(HTTP_OK).json({ scenarios: Array.from(scenarios.keys()) });
-      default:
-        return res.status(HTTP_INTERNAL_SERVER_ERROR).json({ error: 'Unknown Type' });
+    const data = req.body;
+    if (data.Type) {
+      switch (data.Type) {
+        case 'Aid':
+          handleAid(data);
+          return res.status(HTTP_OK).json({ aids: Array.from(aids) });
+        case 'Comm':
+          handleComm(data);
+          return res.status(HTTP_OK).json({ logLength: logEntries.length });
+        case 'Scenarios':
+          handleScenarios(data);
+          return res.status(HTTP_OK).json({ scenarios: Array.from(scenarios.keys()) });
+        default:
+          return res.status(HTTP_INTERNAL_SERVER_ERROR).json({ error: 'Unknown Type' });
+      }
     }
+
+    if (data.Aid) handleAid(data.Aid);
+    if (data.Comm) handleComm(data.Comm);
+    if (data.Scenarios) handleScenarios(data.Scenarios);
+
+    return res.status(HTTP_OK).json({
+      aids: Array.from(aids),
+      logLength: logEntries.length,
+      scenarios: Array.from(scenarios.keys())
+    });
   } catch (err) {
     console.error(err);
     res.status(HTTP_INTERNAL_SERVER_ERROR).json({ error: 'Internal Server Error' });

--- a/example-server/server.js
+++ b/example-server/server.js
@@ -79,6 +79,12 @@ function handleScenarios({ Add, Remove, Clear, Current }) {
   if (Current) console.log(`Set current scenario to ${Current}`);
 }
 
+// Polling endpoint used by the app's ServerConnectionManager. Respond with an
+// empty body so URL.readText() succeeds without generating log entries.
+app.get('/', (_req, res) => {
+  res.status(HTTP_OK).end();
+});
+
 app.listen(PORT, () => {
   console.log(`External server listening on port ${PORT}`);
 });

--- a/example-server/server.js
+++ b/example-server/server.js
@@ -1,0 +1,72 @@
+const express = require('express');
+
+const HTTP_OK = 200;
+const HTTP_INTERNAL_SERVER_ERROR = 500;
+const PORT = process.env.PORT || 1818;
+
+const app = express();
+app.use(express.json());
+
+// In-memory stores for AIDs, scenarios and log entries.
+const aids = new Set();
+const scenarios = new Map();
+let logEntries = [];
+
+// Unified POST endpoint matching the app's internal server API.
+app.post('/', async (req, res) => {
+  try {
+    const { Type } = req.body;
+    switch (Type) {
+      case 'Aid':
+        handleAid(req.body);
+        return res.status(HTTP_OK).json({ aids: Array.from(aids) });
+      case 'Comm':
+        handleComm(req.body);
+        return res.status(HTTP_OK).json({ logLength: logEntries.length });
+      case 'Scenarios':
+        handleScenarios(req.body);
+        return res.status(HTTP_OK).json({ scenarios: Array.from(scenarios.keys()) });
+      default:
+        return res.status(HTTP_INTERNAL_SERVER_ERROR).json({ error: 'Unknown Type' });
+    }
+  } catch (err) {
+    console.error(err);
+    res.status(HTTP_INTERNAL_SERVER_ERROR).json({ error: 'Internal Server Error' });
+  }
+});
+
+function handleAid({ Add, Remove, Clear }) {
+  if (Clear) aids.clear();
+  if (Add) {
+    const list = Array.isArray(Add) ? Add : [Add];
+    list.forEach(aid => aids.add(aid));
+  }
+  if (Remove) {
+    const list = Array.isArray(Remove) ? Remove : [Remove];
+    list.forEach(aid => aids.delete(aid));
+  }
+}
+
+function handleComm({ Clear, Save, Mute, CurrentScenario }) {
+  if (Clear) logEntries = [];
+  if (Save) console.log('Saving log', logEntries);
+  if (typeof Mute === 'boolean') console.log(`Communication ${Mute ? 'muted' : 'unmuted'}`);
+  if (CurrentScenario) console.log(`Current scenario: ${CurrentScenario}`);
+}
+
+function handleScenarios({ Add, Remove, Clear, Current }) {
+  if (Clear) scenarios.clear();
+  if (Add) {
+    const list = Array.isArray(Add) ? Add : [Add];
+    list.forEach(sc => scenarios.set(sc.name, sc));
+  }
+  if (Remove) {
+    const list = Array.isArray(Remove) ? Remove : [Remove];
+    list.forEach(name => scenarios.delete(name));
+  }
+  if (Current) console.log(`Set current scenario to ${Current}`);
+}
+
+app.listen(PORT, () => {
+  console.log(`External server listening on port ${PORT}`);
+});


### PR DESCRIPTION
## Summary
- add example Node.js server that mirrors the app's HTTP control API for external use
- document how to run the example server and reference it from main README

## Testing
- `./gradlew test` *(fails: SDK location not found)*
- `npm install` in `example-server` *(fails: 403 Forbidden when fetching express)*

------
https://chatgpt.com/codex/tasks/task_e_68b70674a7b0833095da148407834834