### PR TITLE
Add discovery endpoints and enhance log saving

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -51,6 +51,7 @@ dependencies {
     implementation(libs.androidx.material3)
     implementation(libs.androidx.runtime.saveable)
     implementation(libs.androidx.material.icons.extended)
+    implementation(libs.androidx.documentfile)
     testImplementation(libs.junit)
     testImplementation(platform(libs.androidx.compose.bom))
     testImplementation(libs.androidx.ui.test.junit4)

--- a/app/src/main/java/com/lnkv/nfcemulator/CommunicationLog.kt
+++ b/app/src/main/java/com/lnkv/nfcemulator/CommunicationLog.kt
@@ -4,6 +4,7 @@ import android.util.Log
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import java.io.File
+import java.io.OutputStream
 import kotlin.collections.ArrayDeque
 
 /**
@@ -54,7 +55,23 @@ object CommunicationLog {
      */
     fun saveToFile(file: File, entries: List<Entry> = buffer.toList()) {
         Log.d(TAG, "saveToFile: ${file.path}")
+        file.parentFile?.let { parent ->
+            if (!parent.exists()) {
+                parent.mkdirs()
+            }
+        }
+        file.outputStream().use { stream ->
+            saveToStream(stream, entries)
+        }
+    }
+
+    /**
+     * Writes provided [entries] to the supplied [outputStream].
+     */
+    fun saveToStream(outputStream: OutputStream, entries: List<Entry> = buffer.toList()) {
         val text = entries.joinToString("\n") { it.message }
-        file.writeText(text)
+        outputStream.bufferedWriter().use { writer ->
+            writer.write(text)
+        }
     }
 }

--- a/app/src/main/java/com/lnkv/nfcemulator/InternalServerManager.kt
+++ b/app/src/main/java/com/lnkv/nfcemulator/InternalServerManager.kt
@@ -43,46 +43,78 @@ object InternalServerManager {
                         launch {
                             var cleared = false
                             try {
-                        val reader = socket.getInputStream().bufferedReader()
-                        val requestLine = reader.readLine() ?: ""
-                        val parts = requestLine.split(" ")
-                        val method = parts.getOrElse(0) { "" }
-                        val path = parts.getOrElse(1) { "/" }
-                        val headers = mutableListOf<String>()
-                        while (true) {
-                            val line = reader.readLine() ?: break
-                            if (line.isEmpty()) break
-                            headers.add(line)
-                        }
-                        val contentLength = headers.firstOrNull {
-                            it.startsWith("Content-Length", ignoreCase = true)
-                        }?.substringAfter(":")?.trim()?.toIntOrNull() ?: 0
-                        if (method.equals("GET", true) && path.equals("/STATUS", true)) {
-                            val status = AppStatusManager.current
-                            val resp = "HTTP/1.1 200 OK\r\nContent-Length: ${status.length}\r\n\r\n$status"
-                            try { socket.getOutputStream().apply { write(resp.toByteArray()); flush() } } catch (_: Exception) {}
-                        } else if (method.equals("POST", true)) {
-                            val bodyChars = CharArray(contentLength)
-                            var read = 0
-                            while (read < contentLength) {
-                                val r = reader.read(bodyChars, read, contentLength - read)
-                                if (r == -1) break
-                                read += r
-                            }
-                            val body = String(bodyChars, 0, read)
-                            Log.d(TAG, "request: $body")
-                            if (body.isNotBlank()) {
-                                CommunicationLog.add("POST: $body", true, true)
-                                cleared = ServerJsonHandler.handle(body)
-                            }
-                            try {
-                                socket.getOutputStream().apply {
-                                    write("HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nOK".toByteArray())
-                                    flush()
+                                val reader = socket.getInputStream().bufferedReader()
+                                val requestLine = reader.readLine() ?: ""
+                                val parts = requestLine.split(" ")
+                                val method = parts.getOrElse(0) { "" }
+                                val path = parts.getOrElse(1) { "/" }
+                                val headers = mutableListOf<String>()
+                                while (true) {
+                                    val line = reader.readLine() ?: break
+                                    if (line.isEmpty()) break
+                                    headers.add(line)
                                 }
-                            } catch (_: Exception) {
-                            }
-                        }
+                                val contentLength = headers.firstOrNull {
+                                    it.startsWith("Content-Length", ignoreCase = true)
+                                }?.substringAfter(":")?.trim()?.toIntOrNull() ?: 0
+
+                                val output = socket.getOutputStream()
+                                fun writeResponse(statusLine: String, body: String = "") {
+                                    val bodyBytes = body.toByteArray()
+                                    val header = StringBuilder()
+                                        .append(statusLine)
+                                        .append("\r\nContent-Length: ")
+                                        .append(bodyBytes.size)
+                                        .append("\r\nContent-Type: text/plain\r\n\r\n")
+                                    try {
+                                        output.write(header.toString().toByteArray())
+                                        if (bodyBytes.isNotEmpty()) {
+                                            output.write(bodyBytes)
+                                        }
+                                        output.flush()
+                                    } catch (_: Exception) {
+                                    }
+                                }
+
+                                when {
+                                    method.equals("GET", true) -> {
+                                        when {
+                                            path.equals("/STATUS", true) -> {
+                                                writeResponse("HTTP/1.1 200 OK", AppStatusManager.current)
+                                            }
+                                            path.equals("/APP-NFC", true) -> {
+                                                writeResponse("HTTP/1.1 200 OK", "APP-NFC")
+                                            }
+                                            path.equals("/timestamp", true) -> {
+                                                val now = System.currentTimeMillis().toString()
+                                                CommunicationLog.add("REQUESTED TIMESTAMP: $now", true, true)
+                                                writeResponse("HTTP/1.1 200 OK", now)
+                                            }
+                                            else -> {
+                                                writeResponse("HTTP/1.1 404 Not Found")
+                                            }
+                                        }
+                                    }
+                                    method.equals("POST", true) -> {
+                                        val bodyChars = CharArray(contentLength)
+                                        var read = 0
+                                        while (read < contentLength) {
+                                            val r = reader.read(bodyChars, read, contentLength - read)
+                                            if (r == -1) break
+                                            read += r
+                                        }
+                                        val body = String(bodyChars, 0, read)
+                                        Log.d(TAG, "request: $body")
+                                        if (body.isNotBlank()) {
+                                            CommunicationLog.add("POST: $body", true, true)
+                                            cleared = ServerJsonHandler.handle(body)
+                                        }
+                                        writeResponse("HTTP/1.1 200 OK", "OK")
+                                    }
+                                    else -> {
+                                        writeResponse("HTTP/1.1 405 Method Not Allowed")
+                                    }
+                                }
                             } catch (e: Exception) {
                                 Log.d(TAG, "client error: ${e.message}")
                             } finally {

--- a/app/src/main/java/com/lnkv/nfcemulator/InternalServerManager.kt
+++ b/app/src/main/java/com/lnkv/nfcemulator/InternalServerManager.kt
@@ -82,8 +82,8 @@ object InternalServerManager {
                                             path.equals("/STATUS", true) -> {
                                                 writeResponse("HTTP/1.1 200 OK", AppStatusManager.current)
                                             }
-                                            path.equals("/APP-NFC", true) -> {
-                                                writeResponse("HTTP/1.1 200 OK", "APP-NFC")
+                                            path.equals("/app", true) -> {
+                                                writeResponse("HTTP/1.1 200 OK", "NFC-EMULATOR")
                                             }
                                             path.equals("/timestamp", true) -> {
                                                 val now = System.currentTimeMillis().toString()

--- a/app/src/main/java/com/lnkv/nfcemulator/ServerJsonHandler.kt
+++ b/app/src/main/java/com/lnkv/nfcemulator/ServerJsonHandler.kt
@@ -213,8 +213,15 @@ object ServerJsonHandler {
     }
 
     private fun updateLogPath(rawPath: String) {
+        val validation = CommunicationLog.validatePath(rawPath)
+        if (!validation.isValid) {
+            val reason = validation.errorMessage ?: "Invalid path"
+            CommunicationLog.add("STATE-COMM: Invalid log path ($rawPath): $reason", true, false)
+            Log.d(TAG, "handleComm: invalid log path input=$rawPath reason=$reason")
+            return
+        }
         val previous = CommunicationLog.logPath.value
-        val sanitized = CommunicationLog.setLogPath(rawPath)
+        val sanitized = CommunicationLog.setLogPath(validation.sanitized)
         if (sanitized != previous) {
             val directory = CommunicationLog.getResolvedLogDirectoryPath()
             CommunicationLog.add("STATE-COMM: Log directory $directory", true, true)

--- a/example-server/README.md
+++ b/example-server/README.md
@@ -50,4 +50,7 @@ curl -X POST http://localhost:1818/ -H "Content-Type: application/json" \
 ```
 
 The server also exposes `GET /STATUS` to report the last status value posted by
-the app and `POST /STATUS` for the app to send status updates.
+the app and `POST /STATUS` for the app to send status updates. Two helper
+diagnostic endpoints are available as well: `GET /APP-NFC` returns a static
+handshake string so you can verify you are querying the emulator server, and
+`GET /timestamp` responds with the current Unix timestamp in milliseconds.

--- a/example-server/README.md
+++ b/example-server/README.md
@@ -51,9 +51,10 @@ curl -X POST http://localhost:1818/ -H "Content-Type: application/json" \
 
 The server also exposes `GET /STATUS` to report the last status value posted by
 the app and `POST /STATUS` for the app to send status updates. Two helper
-diagnostic endpoints are available as well: `GET /APP-NFC` returns a static
-handshake string so you can verify you are querying the emulator server, and
-`GET /timestamp` responds with the current Unix timestamp in milliseconds.
+diagnostic endpoints are available as well: `GET /app` returns a static
+`NFC-EMULATOR` handshake string so you can verify you are querying the emulator
+server, and `GET /timestamp` responds with the current Unix timestamp in
+milliseconds.
 
 ## Log management
 

--- a/example-server/README.md
+++ b/example-server/README.md
@@ -54,3 +54,44 @@ the app and `POST /STATUS` for the app to send status updates. Two helper
 diagnostic endpoints are available as well: `GET /APP-NFC` returns a static
 handshake string so you can verify you are querying the emulator server, and
 `GET /timestamp` responds with the current Unix timestamp in milliseconds.
+
+## Log management
+
+In the app, the **Logs** button now opens a dedicated screen where you can:
+
+* Configure the log storage limit between `0` and `100` megabytes. When the
+  limit is greater than zero, the emulator automatically removes the oldest log
+  files inside its internal `logs/` directory before and after saving so the
+  total size stays within the configured cap. A value of `0` disables automatic
+  cleanup.
+* Specify an optional relative path (for example `Weekly3`) that will be created
+  beneath the default log directory. Saved files continue to use the scenario
+  name plus a timestamp (e.g. `MyScenario_20240101_120000_000.log`).
+* Trigger a save directly from the screen. The app stores logs under
+  `Android/data/<package>/files/logs/` (or the equivalent internal storage
+  directory if external storage is unavailable) and applies both the chosen path
+  and storage limit automatically.
+
+Both the path and the storage limit are persisted locally and may be adjusted by
+server commands. The `Comm` payload accepts a new `Logs` object in addition to
+the existing `Save` field:
+
+```json
+{
+  "Comm": {
+    "Logs": {
+      "Path": "Weekly3",
+      "MaxStorageMb": 50,
+      "Save": true
+    }
+  }
+}
+```
+
+`Path` and `MaxStorageMb` update the persisted values. Setting `Save` (or the
+existing top-level `Comm.Save`) to `true` writes the current communication log
+using those stored preferences. Sending a string to `Comm.Save` still updates the
+path and performs an immediate save, and nested objects may include
+`Enabled:false` to skip writing while changing settings. The example server logs
+each change and echoes the effective storage configuration when a save request
+is processed.

--- a/example-server/server.js
+++ b/example-server/server.js
@@ -110,6 +110,17 @@ app.get('/STATUS', (_req, res) => {
   res.status(HTTP_OK).json({ status: appStatus });
 });
 
+app.get('/APP-NFC', (_req, res) => {
+  console.log('GET /APP-NFC -> APP-NFC');
+  res.status(HTTP_OK).send('APP-NFC');
+});
+
+app.get('/timestamp', (_req, res) => {
+  const now = Date.now().toString();
+  console.log(`GET /timestamp -> ${now}`);
+  res.status(HTTP_OK).send(now);
+});
+
 app.post('/STATUS', (req, res) => {
   const { status } = req.body || {};
   if (typeof status === 'string') {

--- a/example-server/server.js
+++ b/example-server/server.js
@@ -166,9 +166,9 @@ app.get('/STATUS', (_req, res) => {
   res.status(HTTP_OK).json({ status: appStatus });
 });
 
-app.get('/APP-NFC', (_req, res) => {
-  console.log('GET /APP-NFC -> APP-NFC');
-  res.status(HTTP_OK).send('APP-NFC');
+app.get('/app', (_req, res) => {
+  console.log('GET /app -> NFC-EMULATOR');
+  res.status(HTTP_OK).send('NFC-EMULATOR');
 });
 
 app.get('/timestamp', (_req, res) => {

--- a/example-server/server.js
+++ b/example-server/server.js
@@ -12,6 +12,10 @@ const aids = new Set();
 const scenarios = new Map();
 let logEntries = [];
 let appStatus = 'IDLE';
+const logSettings = {
+  path: '',
+  maxStorageMb: 10,
+};
 
 // Queue of pending commands for the app to fetch via GET /
 const queue = [];
@@ -67,11 +71,63 @@ function handleAid({ Add, Remove, Clear }) {
   }
 }
 
-function handleComm({ Clear, Save, Mute, CurrentScenario }) {
+function handleComm({ Clear, Save, Mute, CurrentScenario, Logs }) {
   if (Clear) logEntries = [];
-  if (Save) console.log('Saving log', logEntries);
+  if (Logs) applyLogSettings(Logs);
+  if (Save) handleSaveRequest(Save);
   if (typeof Mute === 'boolean') console.log(`Communication ${Mute ? 'muted' : 'unmuted'}`);
   if (CurrentScenario) console.log(`Current scenario: ${CurrentScenario}`);
+}
+
+function applyLogSettings(settings) {
+  if (typeof settings !== 'object' || settings === null) return;
+  const path = settings.Path ?? settings.path;
+  if (typeof path === 'string') {
+    logSettings.path = path.trim();
+    console.log(`Updated log path to '${logSettings.path || '/'}'`);
+  }
+
+  const limitRaw = settings.MaxStorageMb ?? settings.maxStorageMb;
+  if (limitRaw !== undefined) {
+    const parsed = Number(limitRaw);
+    if (!Number.isNaN(parsed)) {
+      const limit = Math.max(0, Math.min(100, Math.round(parsed)));
+      logSettings.maxStorageMb = limit;
+      console.log(`Updated log max storage to ${limit} MB`);
+    }
+  }
+
+  const save = settings.Save ?? settings.save;
+  if (save) {
+    handleSaveRequest(save);
+  }
+}
+
+function handleSaveRequest(save) {
+  if (!save) return;
+  if (typeof save === 'string') {
+    logSettings.path = save.trim();
+  } else if (typeof save === 'object') {
+    if (typeof save.Path === 'string' || typeof save.path === 'string') {
+      logSettings.path = (save.Path ?? save.path).trim();
+    }
+    const limitRaw = save.MaxStorageMb ?? save.maxStorageMb;
+    if (limitRaw !== undefined) {
+      const parsed = Number(limitRaw);
+      if (!Number.isNaN(parsed)) {
+        logSettings.maxStorageMb = Math.max(0, Math.min(100, Math.round(parsed)));
+      }
+    }
+    if (save.Enabled === false || save.enabled === false) {
+      console.log('Skip log save (disabled by server command)');
+      return;
+    }
+  }
+  console.log('Saving log with settings', {
+    path: logSettings.path || '/',
+    maxStorageMb: logSettings.maxStorageMb,
+    entries: logEntries,
+  });
 }
 
 function handleScenarios({ Add, Remove, Clear, Current }) {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -27,6 +27,7 @@ androidx-material3 = { group = "androidx.compose.material3", name = "material3" 
 androidx-runtime-saveable = { group = "androidx.compose.runtime", name = "runtime-saveable" }
 androidx-material-icons-extended = { group = "androidx.compose.material", name = "material-icons-extended" }
 androidx-test-core = { group = "androidx.test", name = "core", version = "1.5.0" }
+androidx-documentfile = { group = "androidx.documentfile", name = "documentfile", version = "1.0.1" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
## Summary
- add /APP-NFC and /timestamp endpoints to both internal and example servers, logging timestamp requests
- update communication log saving to prompt for a folder, support server-provided directories, and share timestamped filenames
- ensure scenarios stop before clearing, color server status text, and document new helper endpoints

## Testing
- ./gradlew test *(fails: Android SDK not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68c9c8f00b4c83309dda4f24ea395e27