### PR TITLE
Expose NFC toggle on communication screen

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,10 @@ You can also open the project in Android Studio and run it directly on a connect
 
 1. Install the app on an NFC-capable Android device.
 2. Enter up to two Application Identifiers (AIDs) in the provided fields.
-3. Tap **Save AIDs** and hold the device near an NFC reader.
-4. The communication log at the bottom shows APDU requests (red) and responses (green),
+3. Toggle **NFC Emulation** from the **AID** screen when you need to disable or re-enable
+   all NFC communication (including Android's native wait frames).
+4. Tap **Save AIDs** and hold the device near an NFC reader.
+5. The communication log at the bottom shows APDU requests (red) and responses (green),
    along with scenario state changes and NFC activation or deactivation events.
 
 ## HTTP Control API
@@ -75,11 +77,14 @@ Manage registered Application Identifiers.
   "Aid": {
     "Add": ["A0000002471001", "A0000002471002"],   // optional AIDs to add
     "Remove": ["A0000002471003"],                  // optional AIDs to remove
-    "Clear": false                                 // set true to unregister all AIDs
+    "Clear": false,                                // set true to unregister all AIDs
+    "Enabled": true                                // set false to block all NFC comms
   }
 }
 ```
 `Add` and `Remove` accept either a single string or an array of strings.
+`Enabled` toggles whether the phone responds to NFC readers. Disabling it removes the
+registered AIDs until it is re-enabled.
 
 #### `Comm`
 
@@ -91,10 +96,15 @@ Control the communication log and scenarios.
     "Clear": false,            // clear the log when true
     "Save": true,              // save log to file when true
     "Mute": false,             // mute/unmute communication
+    "NfcEnabled": true,        // toggle NFC emulation on the device
     "CurrentScenario": "Start" // "Start", "Stop" or "Clear"
   }
 }
 ```
+
+`NfcEnabled` mirrors the toggle available on the Communication screen. When set
+to `false`, the device will stop responding to NFC readers and log the change in
+the server communication feed.
 
 Requests receive a simple `200 OK` response. Additional command types may be
 introduced in future versions.

--- a/app/src/main/java/com/lnkv/nfcemulator/AidManager.kt
+++ b/app/src/main/java/com/lnkv/nfcemulator/AidManager.kt
@@ -4,9 +4,12 @@ import android.content.ComponentName
 import android.content.SharedPreferences
 import android.nfc.cardemulation.CardEmulation
 import android.util.Log
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
 
 object AidManager {
     private const val PREFS_KEY = "aids"
+    private const val ENABLED_KEY = "enabled"
     private const val TAG = "AidManager"
 
     lateinit var cardEmulation: CardEmulation
@@ -16,15 +19,32 @@ object AidManager {
     lateinit var prefs: SharedPreferences
         private set
 
+    private var enabled = true
+    private val _enabledState = MutableStateFlow(true)
+    val enabledFlow = _enabledState.asStateFlow()
+
+    val isEnabled: Boolean
+        get() = enabled
+
     fun init(cardEmulation: CardEmulation, componentName: ComponentName, prefs: SharedPreferences) {
         Log.d(TAG, "init: component=$componentName")
         this.cardEmulation = cardEmulation
         this.componentName = componentName
         this.prefs = prefs
+        enabled = prefs.getBoolean(ENABLED_KEY, true)
+        _enabledState.value = enabled
     }
 
     fun registerAids(aids: List<String>) {
-        Log.d(TAG, "registerAids: $aids")
+        Log.d(TAG, "registerAids: $aids enabled=$enabled")
+        if (!enabled) {
+            Log.d(TAG, "registerAids: disabled, clearing registered AIDs")
+            cardEmulation.removeAidsForService(
+                componentName,
+                CardEmulation.CATEGORY_OTHER
+            )
+            return
+        }
         if (aids.isEmpty()) {
             Log.d(TAG, "registerAids: clearing all")
             cardEmulation.removeAidsForService(
@@ -38,6 +58,32 @@ object AidManager {
                 aids
             )
         }
+    }
+
+    fun setEnabled(value: Boolean) {
+        if (enabled == value) return
+        enabled = value
+        _enabledState.value = value
+        prefs.edit().putBoolean(ENABLED_KEY, value).apply()
+        if (value) {
+            val aids = prefs.getStringSet(PREFS_KEY, emptySet())!!.toList()
+            registerAids(aids)
+            CommunicationLog.add("STATE-NFC: Enabled by user.", true, true)
+        } else {
+            cardEmulation.removeAidsForService(
+                componentName,
+                CardEmulation.CATEGORY_OTHER
+            )
+            CommunicationLog.add("STATE-NFC: Disabled by user.", true, false)
+        }
+        RequestStateTracker.markChanged()
+    }
+
+    fun replaceAll(aids: Collection<String>) {
+        val set = aids.toSet()
+        prefs.edit().putStringSet(PREFS_KEY, set).apply()
+        registerAids(set.toList())
+        RequestStateTracker.markChanged()
     }
 
     fun add(aid: String) {

--- a/example-server/multi-command-request.json
+++ b/example-server/multi-command-request.json
@@ -1,6 +1,7 @@
 {
   "Aid": {
     "Clear": true,
+    "Enabled": true,
     "Add": ["A0000002471001", "A0000002471002"]
   },
   "Scenarios": {
@@ -15,6 +16,6 @@
     ],
     "Current": "SampleScenario"
   },
-  "Comm": { "Clear": true },
+  "Comm": { "Clear": true, "NfcEnabled": false },
   "Filters": { "Add": "A0B1" }
 }


### PR DESCRIPTION
## Summary
- add state tracking in `AidManager` to enable or disable NFC emulation and surface the state as a flow
- expose NFC emulation controls on both the AID and Communication screens, wiring UI toggles to shared logging and persistence
- extend the HTTP API, documentation, and example payload to support the `Enabled` flag and remote `Comm.NfcEnabled` updates, and shorten long scenario names with a `( .. )` indicator on the Communication header

## Testing
- ⚠️ `./gradlew test` *(fails: Android SDK is not available in the container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cb154f8a2c833089087259a21fd15a