### PR TITLE
Remove NFC toggle from AID screen

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,8 @@ You can also open the project in Android Studio and run it directly on a connect
 
 1. Install the app on an NFC-capable Android device.
 2. Enter up to two Application Identifiers (AIDs) in the provided fields.
-3. Toggle **NFC Emulation** from the **AID** screen when you need to disable or re-enable
-   all NFC communication (including Android's native wait frames).
+3. Toggle **NFC emulation** from the **Communication** screen when you need to disable or
+   re-enable all NFC communication (including Android's native wait frames).
 4. Tap **Save AIDs** and hold the device near an NFC reader.
 5. The communication log at the bottom shows APDU requests (red) and responses (green),
    along with scenario state changes and NFC activation or deactivation events.

--- a/app/src/main/java/com/lnkv/nfcemulator/MainActivity.kt
+++ b/app/src/main/java/com/lnkv/nfcemulator/MainActivity.kt
@@ -1365,8 +1365,6 @@ fun AidScreen(modifier: Modifier = Modifier) {
     val context = LocalContext.current
     val aids = remember { loadAids(context) }
     var newAid by remember { mutableStateOf("") }
-    val isEnabled by AidManager.enabledFlow.collectAsState()
-
     val exportLauncher = rememberLauncherForActivityResult(
         ActivityResultContracts.CreateDocument("application/json")
     ) { uri ->
@@ -1387,32 +1385,6 @@ fun AidScreen(modifier: Modifier = Modifier) {
     }
 
     Column(modifier = modifier.fillMaxSize().padding(16.dp)) {
-        Row(
-            verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.spacedBy(12.dp)
-        ) {
-            CircleCheckbox(
-                checked = isEnabled,
-                onCheckedChange = { enabled ->
-                    AidManager.setEnabled(enabled)
-                    val message = if (enabled) {
-                        "NFC emulation enabled"
-                    } else {
-                        "NFC emulation disabled"
-                    }
-                    Toast.makeText(context, message, Toast.LENGTH_SHORT).show()
-                }
-            )
-            Column {
-                Text("NFC Emulation", fontWeight = FontWeight.SemiBold)
-                Text(
-                    if (isEnabled) "The phone will respond to NFC readers." else "All NFC communication is blocked.",
-                    fontSize = 12.sp,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant
-                )
-            }
-        }
-        Spacer(modifier = Modifier.height(16.dp))
         Row(
             verticalAlignment = Alignment.CenterVertically,
             horizontalArrangement = Arrangement.spacedBy(8.dp)


### PR DESCRIPTION
## Summary
- remove the NFC emulation toggle UI from the AID screen
- update the README usage instructions to point to the Communication screen for the NFC toggle

## Testing
- ./gradlew lint *(fails: SDK location not configured in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cc791c6a1083308d426435ee2a49ad